### PR TITLE
[refactor] 사이드바를 재귀적 구조로 개선

### DIFF
--- a/apps/client/src/widgets/docs/config/docsSections.ts
+++ b/apps/client/src/widgets/docs/config/docsSections.ts
@@ -7,6 +7,10 @@ export interface DocsSection {
   children?: {
     label: string;
     href: string;
+    children?: {
+      label: string;
+      href: string;
+    }[];
   }[];
 }
 
@@ -17,36 +21,41 @@ export const docsSections: DocsSection[] = [
     icon: BookOpen,
   },
   {
-    label: 'OpenAPI - HTTP',
+    label: 'OpenAPI',
     href: '/docs/api',
     icon: Code2,
     children: [
       {
-        label: '학생 데이터 OpenAPI',
-        href: '/docs/api/http/student',
+        label: 'HTTP',
+        href: '/docs/api/http',
+        children: [
+          {
+            label: '학생 데이터 OpenAPI',
+            href: '/docs/api/http/student',
+          },
+          {
+            label: '동아리 데이터 OpenAPI',
+            href: '/docs/api/http/club',
+          },
+          {
+            label: '프로젝트 데이터 OpenAPI',
+            href: '/docs/api/http/project',
+          },
+          {
+            label: 'NEIS 데이터 OpenAPI',
+            href: '/docs/api/http/neis',
+          },
+        ],
       },
       {
-        label: '동아리 데이터 OpenAPI',
-        href: '/docs/api/http/club',
-      },
-      {
-        label: '프로젝트 데이터 OpenAPI',
-        href: '/docs/api/http/project',
-      },
-      {
-        label: 'NEIS 데이터 OpenAPI',
-        href: '/docs/api/http/neis',
-      },
-    ],
-  },
-  {
-    label: 'OpenAPI - SDK',
-    href: '/docs/api/sdk',
-    icon: Code2,
-    children: [
-      {
-        label: 'Java / Kotlin SDK',
-        href: '/docs/api/sdk/java',
+        label: 'SDK',
+        href: '/docs/api/sdk',
+        children: [
+          {
+            label: 'Java / Kotlin SDK',
+            href: '/docs/api/sdk/java',
+          },
+        ],
       },
     ],
   },

--- a/apps/client/src/widgets/docs/index.ts
+++ b/apps/client/src/widgets/docs/index.ts
@@ -1,3 +1,4 @@
 export { default as DocsSidebar } from './ui/DocsSidebar';
 export { default as CodeTabs, CodeTab } from './ui/CodeTabs';
-export * from './config/docsSections';
+export * from './model/constants';
+export * from './model/types';

--- a/apps/client/src/widgets/docs/model/constants.ts
+++ b/apps/client/src/widgets/docs/model/constants.ts
@@ -1,18 +1,6 @@
 import { BookOpen, Code2, User } from 'lucide-react';
 
-export interface DocsSection {
-  label: string;
-  href: string;
-  icon: React.ElementType;
-  children?: {
-    label: string;
-    href: string;
-    children?: {
-      label: string;
-      href: string;
-    }[];
-  }[];
-}
+import { DocsSection } from './types';
 
 export const docsSections: DocsSection[] = [
   {

--- a/apps/client/src/widgets/docs/model/types.ts
+++ b/apps/client/src/widgets/docs/model/types.ts
@@ -1,0 +1,13 @@
+export interface DocsSection {
+  label: string;
+  href: string;
+  icon: React.ElementType;
+  children?: {
+    label: string;
+    href: string;
+    children?: {
+      label: string;
+      href: string;
+    }[];
+  }[];
+}

--- a/apps/client/src/widgets/docs/model/types.ts
+++ b/apps/client/src/widgets/docs/model/types.ts
@@ -1,13 +1,9 @@
-export interface DocsSection {
+export interface DocsSectionItem {
   label: string;
   href: string;
+  children?: DocsSectionItem[];
+}
+
+export interface DocsSection extends DocsSectionItem {
   icon: React.ElementType;
-  children?: {
-    label: string;
-    href: string;
-    children?: {
-      label: string;
-      href: string;
-    }[];
-  }[];
 }

--- a/apps/client/src/widgets/docs/ui/DocsSidebar/index.tsx
+++ b/apps/client/src/widgets/docs/ui/DocsSidebar/index.tsx
@@ -16,9 +16,18 @@ const SidebarContent = ({ onLinkClick }: { onLinkClick?: () => void }) => {
   const isActive = (href: string) => pathname === href;
   const isDescendant = (href: string) => pathname === href || pathname.startsWith(`${href}/`);
 
-  const [openMap, setOpenMap] = useState<Record<string, boolean>>(() =>
-    Object.fromEntries(docsSections.map((section) => [section.href, isDescendant(section.href)])),
-  );
+  const [openMap, setOpenMap] = useState<Record<string, boolean>>(() => {
+    const map: Record<string, boolean> = {};
+    docsSections.forEach((section) => {
+      map[section.href] = isDescendant(section.href);
+      if (section.children) {
+        section.children.forEach((child) => {
+          map[child.href] = isDescendant(child.href);
+        });
+      }
+    });
+    return map;
+  });
 
   const toggle = (href: string) => {
     setOpenMap((prev) => ({
@@ -62,22 +71,67 @@ const SidebarContent = ({ onLinkClick }: { onLinkClick?: () => void }) => {
             </div>
 
             {children && isOpen && (
-              <div className="mt-1 space-y-1 pl-9">
-                {children.map((child) => (
-                  <Link
-                    key={child.href}
-                    href={child.href}
-                    onClick={onLinkClick}
-                    className={cn(
-                      'block rounded-md px-3 py-1.5 text-sm transition-colors',
-                      isActive(child.href)
-                        ? 'bg-primary/10 text-primary'
-                        : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-                    )}
-                  >
-                    {child.label}
-                  </Link>
-                ))}
+              <div className="mt-1 space-y-1 pl-6">
+                {children.map((child) => {
+                  const isChildOpen = openMap[child.href];
+
+                  return (
+                    <div key={child.href}>
+                      <div
+                        className={cn(
+                          'flex items-center justify-between rounded-md px-3 py-1.5 text-sm transition-colors',
+                          isActive(child.href)
+                            ? 'bg-primary/10 text-primary'
+                            : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                        )}
+                      >
+                        <Link
+                          href={child.href}
+                          onClick={onLinkClick}
+                          className="flex flex-1 items-center"
+                        >
+                          {child.label}
+                        </Link>
+
+                        {child.children && (
+                          <button
+                            type="button"
+                            onClick={() => toggle(child.href)}
+                            className="p-1"
+                            aria-label={`${child.label} 토글`}
+                          >
+                            <ChevronDown
+                              className={cn(
+                                'h-4 w-4 transition-transform',
+                                isChildOpen && 'rotate-180',
+                              )}
+                            />
+                          </button>
+                        )}
+                      </div>
+
+                      {child.children && isChildOpen && (
+                        <div className="mt-1 space-y-1 pl-6">
+                          {child.children.map((grandChild) => (
+                            <Link
+                              key={grandChild.href}
+                              href={grandChild.href}
+                              onClick={onLinkClick}
+                              className={cn(
+                                'block rounded-md px-3 py-1.5 text-sm transition-colors',
+                                isActive(grandChild.href)
+                                  ? 'bg-primary/10 text-primary'
+                                  : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                              )}
+                            >
+                              {grandChild.label}
+                            </Link>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             )}
           </div>

--- a/apps/client/src/widgets/docs/ui/DocsSidebar/index.tsx
+++ b/apps/client/src/widgets/docs/ui/DocsSidebar/index.tsx
@@ -8,7 +8,7 @@ import { usePathname } from 'next/navigation';
 import { cn } from '@repo/shared/utils';
 import { ChevronDown, Menu, X } from 'lucide-react';
 
-import { docsSections } from '@/widgets/docs/config/docsSections';
+import { docsSections } from '../../model/constants';
 
 const SidebarContent = ({ onLinkClick }: { onLinkClick?: () => void }) => {
   const pathname = usePathname();

--- a/apps/client/src/widgets/docs/ui/DocsSidebar/index.tsx
+++ b/apps/client/src/widgets/docs/ui/DocsSidebar/index.tsx
@@ -9,6 +9,7 @@ import { cn } from '@repo/shared/utils';
 import { ChevronDown, Menu, X } from 'lucide-react';
 
 import { docsSections } from '../../model/constants';
+import { DocsSectionItem } from '../../model/types';
 
 const SidebarContent = ({ onLinkClick }: { onLinkClick?: () => void }) => {
   const pathname = usePathname();
@@ -17,16 +18,17 @@ const SidebarContent = ({ onLinkClick }: { onLinkClick?: () => void }) => {
   const isDescendant = (href: string) => pathname === href || pathname.startsWith(`${href}/`);
 
   const [openMap, setOpenMap] = useState<Record<string, boolean>>(() => {
-    const map: Record<string, boolean> = {};
-    docsSections.forEach((section) => {
-      map[section.href] = isDescendant(section.href);
-      if (section.children) {
-        section.children.forEach((child) => {
-          map[child.href] = isDescendant(child.href);
-        });
-      }
-    });
-    return map;
+    const initialMap: Record<string, boolean> = {};
+    const buildMap = (items: DocsSectionItem[]) => {
+      items.forEach((item) => {
+        if (item.children) {
+          initialMap[item.href] = isDescendant(item.href);
+          buildMap(item.children);
+        }
+      });
+    };
+    buildMap(docsSections);
+    return initialMap;
   });
 
   const toggle = (href: string) => {


### PR DESCRIPTION
## 개요 💡

사이드바를 재귀적 구조로 리팩토링하여 무한 깊이의 중첩을 지원하도록 개선했습니다.

## 작업내용 ⌨️

- 재귀적 타입 구조로 개선 (3단계 제한 제거)
- 재귀적 `SidebarItem` 컴포넌트로 리팩토링 (코드 중복 제거)
- FSD 아키텍쳐에 맞게 구조 개선

## 스크린샷/동영상 📸

<img width="270" height="422" alt="image" src="https://github.com/user-attachments/assets/29298819-0039-4893-9757-42242125fe83" />