### PR TITLE
[fix] Prettier 적용 범위에서 기술문서 구성 파일 제외

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,5 @@ yarn.lock
 package-lock.json
 
 .DS_Store
+
+apps/client/src/app/docs/**/*.mdx


### PR DESCRIPTION
## 개요 💡

Prettier 포맷팅 대상에서 기술문서를 구성한 마크다운 파일들을 제외합니다.

## 작업내용 ⌨️

Prettier가 동작하여 #15 에서 추가된 `CodeTabs` 컴포넌트를 통한 언어별 코드 예제에 적용된 들여쓰기가 삭제되는 문제가 있었습니다.

이러한 기술문서를 구성하는 `mdx` 파일은 크게 포맷팅의 중요성이 없다고 생각하여 해당 경로에 있는 `mdx` 파일을 포맷터의 적용범위에서 제외하도록 수정하였습니다.

## 스크린샷/동영상 📸
기존에는 이런식으로 되었습니다.

<img width="655" height="870" alt="image" src="https://github.com/user-attachments/assets/5254b907-0de4-4e5a-b6cd-f2ce2fcc037e" />
