### PR TITLE
[docs] Pre-Release 시 사용할 OpenAPI 서버 URL을 기술 문서에 반영

### DIFF
--- a/apps/client/src/app/docs/api/http/page.mdx
+++ b/apps/client/src/app/docs/api/http/page.mdx
@@ -68,7 +68,7 @@ API 키는 UUID 형식이며, 30일마다 갱신이 필요합니다. 만료되�
 다음은 cURL을 사용하여 학생 정보를 조회하는 예시입니다.
 
 ```bash
-curl -X GET "https://openapi.data.hellogsm.com/v1/students?grade=1&classNum=1" \
+curl -X GET "https://openapi.data.hellogsm.kr/v1/students?grade=1&classNum=1" \
   -H "X-API-KEY: your-api-key-here"
 ```
 


### PR DESCRIPTION
## 개요 💡

> Pre-Release 시 사용할 서버 주소를 기술문서에 추가하였습니다.

## 작업내용 ⌨️

> Pre-Release 시 사용할 `https://openapi.data.hellogsm.kr` 주소를 OpenAPI HTTP 기술 문서에 추가하였습니다.
SDK 문서에는 추가하지 않았으며 이는 SDK의 경우 추상화되어 있기 때문에 직접 Base URL을 임의로 설정하는 경우가 아니라면 없기 때문입니다.
