### PR TITLE
[feat] code highlighting

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -22,6 +22,7 @@
     "react": "19.2.1",
     "react-dom": "19.2.1",
     "react-hook-form": "^7.67.0",
+    "react-syntax-highlighter": "^16.1.0",
     "remark-gfm": "^4.0.1",
     "zod": "^4.1.13"
   },
@@ -34,6 +35,7 @@
     "@types/node": "^22.15.30",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.33.0",
     "postcss": "^8.5.3",

--- a/apps/client/src/mdx-components.tsx
+++ b/apps/client/src/mdx-components.tsx
@@ -2,27 +2,10 @@ import Image from 'next/image';
 import NextLink from 'next/link';
 
 import type { MDXComponents } from 'mdx/types';
-import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
-import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash';
-import http from 'react-syntax-highlighter/dist/esm/languages/prism/http';
-import java from 'react-syntax-highlighter/dist/esm/languages/prism/java';
-import javascript from 'react-syntax-highlighter/dist/esm/languages/prism/javascript';
-import json from 'react-syntax-highlighter/dist/esm/languages/prism/json';
-import kotlin from 'react-syntax-highlighter/dist/esm/languages/prism/kotlin';
-import powershell from 'react-syntax-highlighter/dist/esm/languages/prism/powershell';
-import python from 'react-syntax-highlighter/dist/esm/languages/prism/python';
-import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
 import CodeTabs, { CodeTab } from '@/widgets/docs/ui/CodeTabs';
 
-SyntaxHighlighter.registerLanguage('http', http);
-SyntaxHighlighter.registerLanguage('javascript', javascript);
-SyntaxHighlighter.registerLanguage('json', json);
-SyntaxHighlighter.registerLanguage('bash', bash);
-SyntaxHighlighter.registerLanguage('python', python);
-SyntaxHighlighter.registerLanguage('java', java);
-SyntaxHighlighter.registerLanguage('kotlin', kotlin);
-SyntaxHighlighter.registerLanguage('powershell', powershell);
+import { CodeBlock } from './shared/ui';
 
 export function useMDXComponents(components: MDXComponents = {}): MDXComponents {
   return {
@@ -53,19 +36,7 @@ export function useMDXComponents(components: MDXComponents = {}): MDXComponents 
       const language = match ? match[1] : '';
 
       if (language) {
-        return (
-          <SyntaxHighlighter
-            language={language}
-            style={vscDarkPlus}
-            customStyle={{
-              margin: 0,
-              borderRadius: '0.5rem',
-              fontSize: '0.875rem',
-            }}
-          >
-            {String(children).replace(/\n$/, '')}
-          </SyntaxHighlighter>
-        );
+        return <CodeBlock language={language}>{String(children).replace(/\n$/, '')}</CodeBlock>;
       }
 
       return (

--- a/apps/client/src/mdx-components.tsx
+++ b/apps/client/src/mdx-components.tsx
@@ -51,9 +51,8 @@ export function useMDXComponents(components: MDXComponents = {}): MDXComponents 
     code: ({ children, className }) => {
       const match = /language-(\w+)/.exec(className || '');
       const language = match ? match[1] : '';
-      const isBlock = className?.includes('language-');
 
-      if (isBlock && language) {
+      if (language) {
         return (
           <SyntaxHighlighter
             language={language}

--- a/apps/client/src/mdx-components.tsx
+++ b/apps/client/src/mdx-components.tsx
@@ -2,6 +2,8 @@ import Image from 'next/image';
 import NextLink from 'next/link';
 
 import type { MDXComponents } from 'mdx/types';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 
 import CodeTabs, { CodeTab } from '@/widgets/docs/ui/CodeTabs';
 
@@ -27,17 +29,27 @@ export function useMDXComponents(components: MDXComponents = {}): MDXComponents 
 
     li: ({ children }) => <li className="mb-2 leading-relaxed">{children}</li>,
 
-    pre: ({ children }) => (
-      <pre className="my-6 overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm text-gray-100">
-        {children}
-      </pre>
-    ),
+    pre: ({ children }) => <div className="my-6">{children}</div>,
 
     code: ({ children, className }) => {
+      const match = /language-(\w+)/.exec(className || '');
+      const language = match ? match[1] : '';
       const isBlock = className?.includes('language-');
 
-      if (isBlock) {
-        return <code className={className}>{children}</code>;
+      if (isBlock && language) {
+        return (
+          <SyntaxHighlighter
+            language={language}
+            style={vscDarkPlus}
+            customStyle={{
+              margin: 0,
+              borderRadius: '0.5rem',
+              fontSize: '0.875rem',
+            }}
+          >
+            {String(children).replace(/\n$/, '')}
+          </SyntaxHighlighter>
+        );
       }
 
       return (

--- a/apps/client/src/mdx-components.tsx
+++ b/apps/client/src/mdx-components.tsx
@@ -2,10 +2,27 @@ import Image from 'next/image';
 import NextLink from 'next/link';
 
 import type { MDXComponents } from 'mdx/types';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { vscDarkPlus } from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
+import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash';
+import http from 'react-syntax-highlighter/dist/esm/languages/prism/http';
+import java from 'react-syntax-highlighter/dist/esm/languages/prism/java';
+import javascript from 'react-syntax-highlighter/dist/esm/languages/prism/javascript';
+import json from 'react-syntax-highlighter/dist/esm/languages/prism/json';
+import kotlin from 'react-syntax-highlighter/dist/esm/languages/prism/kotlin';
+import powershell from 'react-syntax-highlighter/dist/esm/languages/prism/powershell';
+import python from 'react-syntax-highlighter/dist/esm/languages/prism/python';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
 import CodeTabs, { CodeTab } from '@/widgets/docs/ui/CodeTabs';
+
+SyntaxHighlighter.registerLanguage('http', http);
+SyntaxHighlighter.registerLanguage('javascript', javascript);
+SyntaxHighlighter.registerLanguage('json', json);
+SyntaxHighlighter.registerLanguage('bash', bash);
+SyntaxHighlighter.registerLanguage('python', python);
+SyntaxHighlighter.registerLanguage('java', java);
+SyntaxHighlighter.registerLanguage('kotlin', kotlin);
+SyntaxHighlighter.registerLanguage('powershell', powershell);
 
 export function useMDXComponents(components: MDXComponents = {}): MDXComponents {
   return {

--- a/apps/client/src/shared/ui/CodeBlock/index.tsx
+++ b/apps/client/src/shared/ui/CodeBlock/index.tsx
@@ -1,0 +1,44 @@
+import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
+import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash';
+import http from 'react-syntax-highlighter/dist/esm/languages/prism/http';
+import java from 'react-syntax-highlighter/dist/esm/languages/prism/java';
+import javascript from 'react-syntax-highlighter/dist/esm/languages/prism/javascript';
+import json from 'react-syntax-highlighter/dist/esm/languages/prism/json';
+import kotlin from 'react-syntax-highlighter/dist/esm/languages/prism/kotlin';
+import powershell from 'react-syntax-highlighter/dist/esm/languages/prism/powershell';
+import python from 'react-syntax-highlighter/dist/esm/languages/prism/python';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+
+SyntaxHighlighter.registerLanguage('http', http);
+SyntaxHighlighter.registerLanguage('javascript', javascript);
+SyntaxHighlighter.registerLanguage('json', json);
+SyntaxHighlighter.registerLanguage('bash', bash);
+SyntaxHighlighter.registerLanguage('python', python);
+SyntaxHighlighter.registerLanguage('java', java);
+SyntaxHighlighter.registerLanguage('kotlin', kotlin);
+SyntaxHighlighter.registerLanguage('powershell', powershell);
+
+interface CodeBlockProps {
+  language: string;
+  children: string;
+  customStyle?: React.CSSProperties;
+}
+
+const CodeBlock = ({ language, children, customStyle }: CodeBlockProps) => {
+  return (
+    <SyntaxHighlighter
+      language={language}
+      style={vscDarkPlus}
+      customStyle={{
+        margin: 0,
+        borderRadius: '0.5rem',
+        fontSize: '0.875rem',
+        ...customStyle,
+      }}
+    >
+      {children}
+    </SyntaxHighlighter>
+  );
+};
+
+export default CodeBlock;

--- a/apps/client/src/shared/ui/index.ts
+++ b/apps/client/src/shared/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as CodeBlock } from './CodeBlock';

--- a/apps/client/src/widgets/docs/ui/CodeTabs/index.tsx
+++ b/apps/client/src/widgets/docs/ui/CodeTabs/index.tsx
@@ -3,8 +3,25 @@
 import { Children, type ReactNode, isValidElement, useState } from 'react';
 
 import { useCopyToClipboard } from '@repo/shared/hooks';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { vscDarkPlus } from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
+import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash';
+import http from 'react-syntax-highlighter/dist/esm/languages/prism/http';
+import java from 'react-syntax-highlighter/dist/esm/languages/prism/java';
+import javascript from 'react-syntax-highlighter/dist/esm/languages/prism/javascript';
+import json from 'react-syntax-highlighter/dist/esm/languages/prism/json';
+import kotlin from 'react-syntax-highlighter/dist/esm/languages/prism/kotlin';
+import powershell from 'react-syntax-highlighter/dist/esm/languages/prism/powershell';
+import python from 'react-syntax-highlighter/dist/esm/languages/prism/python';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+
+SyntaxHighlighter.registerLanguage('javascript', javascript);
+SyntaxHighlighter.registerLanguage('json', json);
+SyntaxHighlighter.registerLanguage('bash', bash);
+SyntaxHighlighter.registerLanguage('python', python);
+SyntaxHighlighter.registerLanguage('java', java);
+SyntaxHighlighter.registerLanguage('kotlin', kotlin);
+SyntaxHighlighter.registerLanguage('http', http);
+SyntaxHighlighter.registerLanguage('powershell', powershell);
 
 interface CodeTabProps {
   label: string;

--- a/apps/client/src/widgets/docs/ui/CodeTabs/index.tsx
+++ b/apps/client/src/widgets/docs/ui/CodeTabs/index.tsx
@@ -3,6 +3,8 @@
 import { Children, type ReactNode, isValidElement, useState } from 'react';
 
 import { useCopyToClipboard } from '@repo/shared/hooks';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 
 interface CodeTabProps {
   label: string;
@@ -60,11 +62,17 @@ const CodeTabs = ({ children }: CodeTabsProps) => {
       <div>
         {tabs.map((tab, index) => (
           <div key={tab.props.label} className={activeTab === index ? 'block' : 'hidden'}>
-            <pre className="my-0 overflow-x-auto rounded-b-lg bg-gray-900 p-4 text-sm text-gray-100">
-              <code className={`language-${tab.props.language}`}>
-                {String(tab.props.code).trim()}
-              </code>
-            </pre>
+            <SyntaxHighlighter
+              language={tab.props.language}
+              style={vscDarkPlus}
+              customStyle={{
+                margin: 0,
+                borderRadius: '0 0 0.5rem 0.5rem',
+                fontSize: '0.875rem',
+              }}
+            >
+              {String(tab.props.code).trim()}
+            </SyntaxHighlighter>
           </div>
         ))}
       </div>

--- a/apps/client/src/widgets/docs/ui/CodeTabs/index.tsx
+++ b/apps/client/src/widgets/docs/ui/CodeTabs/index.tsx
@@ -3,25 +3,8 @@
 import { Children, type ReactNode, isValidElement, useState } from 'react';
 
 import { useCopyToClipboard } from '@repo/shared/hooks';
-import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
-import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash';
-import http from 'react-syntax-highlighter/dist/esm/languages/prism/http';
-import java from 'react-syntax-highlighter/dist/esm/languages/prism/java';
-import javascript from 'react-syntax-highlighter/dist/esm/languages/prism/javascript';
-import json from 'react-syntax-highlighter/dist/esm/languages/prism/json';
-import kotlin from 'react-syntax-highlighter/dist/esm/languages/prism/kotlin';
-import powershell from 'react-syntax-highlighter/dist/esm/languages/prism/powershell';
-import python from 'react-syntax-highlighter/dist/esm/languages/prism/python';
-import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
-SyntaxHighlighter.registerLanguage('javascript', javascript);
-SyntaxHighlighter.registerLanguage('json', json);
-SyntaxHighlighter.registerLanguage('bash', bash);
-SyntaxHighlighter.registerLanguage('python', python);
-SyntaxHighlighter.registerLanguage('java', java);
-SyntaxHighlighter.registerLanguage('kotlin', kotlin);
-SyntaxHighlighter.registerLanguage('http', http);
-SyntaxHighlighter.registerLanguage('powershell', powershell);
+import { CodeBlock } from '@/shared/ui';
 
 interface CodeTabProps {
   label: string;
@@ -79,17 +62,14 @@ const CodeTabs = ({ children }: CodeTabsProps) => {
       <div>
         {tabs.map((tab, index) => (
           <div key={tab.props.label} className={activeTab === index ? 'block' : 'hidden'}>
-            <SyntaxHighlighter
+            <CodeBlock
               language={tab.props.language}
-              style={vscDarkPlus}
               customStyle={{
-                margin: 0,
                 borderRadius: '0 0 0.5rem 0.5rem',
-                fontSize: '0.875rem',
               }}
             >
               {String(tab.props.code).trim()}
-            </SyntaxHighlighter>
+            </CodeBlock>
           </div>
         ))}
       </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       react-hook-form:
         specifier: ^7.67.0
         version: 7.67.0(react@19.2.1)
+      react-syntax-highlighter:
+        specifier: ^16.1.0
+        version: 16.1.0(react@19.2.1)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -176,6 +179,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.7)
+      '@types/react-syntax-highlighter':
+        specifier: ^15.5.13
+        version: 15.5.13
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.22(postcss@8.5.6)
@@ -364,6 +370,11 @@ packages:
     dependencies:
       '@babel/types': 7.28.5
     dev: true
+
+  /@babel/runtime@7.28.6:
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
+    dev: false
 
   /@babel/template@7.27.2:
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
@@ -1975,10 +1986,20 @@ packages:
       undici-types: 6.21.0
     dev: true
 
+  /@types/prismjs@1.26.5:
+    resolution: {integrity: sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==}
+    dev: false
+
   /@types/react-dom@19.2.3(@types/react@19.2.7):
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
+    dependencies:
+      '@types/react': 19.2.7
+    dev: true
+
+  /@types/react-syntax-highlighter@15.5.13:
+    resolution: {integrity: sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==}
     dependencies:
       '@types/react': 19.2.7
     dev: true
@@ -2990,6 +3011,12 @@ packages:
       reusify: 1.1.0
     dev: true
 
+  /fault@1.0.4:
+    resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
+    dependencies:
+      format: 0.2.2
+    dev: false
+
   /fdir@6.5.0(picomatch@4.0.3):
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -3062,6 +3089,11 @@ packages:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+    dev: false
+
+  /format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
     dev: false
 
   /fraction.js@5.3.4:
@@ -3211,6 +3243,12 @@ packages:
     dependencies:
       function-bind: 1.1.2
 
+  /hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+    dependencies:
+      '@types/hast': 3.0.4
+    dev: false
+
   /hast-util-to-estree@3.1.3:
     resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
     dependencies:
@@ -3260,6 +3298,24 @@ packages:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
     dependencies:
       '@types/hast': 3.0.4
+    dev: false
+
+  /hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+    dev: false
+
+  /highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+    dev: false
+
+  /highlightjs-vue@1.0.0:
+    resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
     dev: false
 
   /ignore@5.3.2:
@@ -3730,6 +3786,13 @@ packages:
     dependencies:
       js-tokens: 4.0.0
     dev: true
+
+  /lowlight@1.20.0:
+    resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
+    dependencies:
+      fault: 1.0.4
+      highlight.js: 10.7.3
+    dev: false
 
   /lucide-react@0.546.0(react@19.2.1):
     resolution: {integrity: sha512-Z94u6fKT43lKeYHiVyvyR8fT7pwCzDu7RyMPpTvh054+xahSgj4HFQ+NmflvzdXsoAjYGdCguGaFKYuvq0ThCQ==}
@@ -4639,6 +4702,11 @@ packages:
     hasBin: true
     dev: true
 
+  /prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+    dev: false
+
   /prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
     dependencies:
@@ -4737,6 +4805,21 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /react-syntax-highlighter@16.1.0(react@19.2.1):
+    resolution: {integrity: sha512-E40/hBiP5rCNwkeBN1vRP+xow1X0pndinO+z3h7HLsHyjztbyjfzNWNKuAsJj+7DLam9iT4AaaOZnueCU+Nplg==}
+    engines: {node: '>= 16.20.2'}
+    peerDependencies:
+      react: '>= 0.14.0'
+    dependencies:
+      '@babel/runtime': 7.28.6
+      highlight.js: 10.7.3
+      highlightjs-vue: 1.0.0
+      lowlight: 1.20.0
+      prismjs: 1.30.0
+      react: 19.2.1
+      refractor: 5.0.0
+    dev: false
+
   /react@19.2.1:
     resolution: {integrity: sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==}
     engines: {node: '>=0.10.0'}
@@ -4794,6 +4877,15 @@ packages:
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
     dev: true
+
+  /refractor@5.0.0:
+    resolution: {integrity: sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==}
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/prismjs': 1.26.5
+      hastscript: 9.0.1
+      parse-entities: 4.0.2
+    dev: false
 
   /regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -4934,6 +5026,7 @@ packages:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
+    requiresBuild: true
 
   /set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}


### PR DESCRIPTION
## 개요 💡

Docs 페이지에 포함된 코드 블록에 문법 하이라이팅을 적용했습니다.

## 작업 내용 ⌨️

* `react-syntax-highlighter` 라이브러리 추가
* 코드 하이라이팅 기능 적용

## 스크린샷/동영상 📸

<img width="1016" height="562" alt="image" src="https://github.com/user-attachments/assets/5883b24f-b7d8-485b-a068-185b3b6769fe" />
