### PR TITLE
[feat] 404 Not Found 페이지 추가

### DIFF
--- a/apps/client/src/app/not-found.tsx
+++ b/apps/client/src/app/not-found.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+
+import { Button } from '@repo/shared/ui';
+import { cn } from '@repo/shared/utils';
+
+const NotFound = () => {
+  return (
+    <div
+      className={cn(
+        'bg-background flex h-[calc(100vh-4.0625rem)] flex-col items-center justify-center px-4',
+      )}
+    >
+      <div className={cn('flex max-w-md flex-col items-center text-center')}>
+        <h1 className={cn('text-foreground text-8xl font-bold tracking-tighter')}>404</h1>
+
+        <p className={cn('text-foreground mt-4 text-xl font-semibold')}>
+          페이지를 찾을 수 없습니다
+        </p>
+
+        <div className={cn('mt-8 flex items-center gap-3')}>
+          <Button asChild>
+            <Link href="/">메인으로 돌아가기</Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link href="/docs">문서 보기</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
## 개요 💡

404 Not Found 페이지 구현했습니다.

## 작업내용 ⌨️

- 404 Not Found 페이지 구현

## 스크린샷/동영상 📸

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/b7763e03-064c-422a-b97b-2027db735b42" />

## 리뷰 참고사항 👀

단순 view라서 레이어 따로 나누지 않고 개발했습니다.