### PR TITLE
[docs] OpenAPI Java SDK 기술 문서 버전 최신화

### DIFF
--- a/apps/client/src/app/docs/api/sdk/java/page.mdx
+++ b/apps/client/src/app/docs/api/sdk/java/page.mdx
@@ -87,7 +87,7 @@ val client = DataGsmClient.builder("your-api-key-here").build()
 
 // 커스텀 Base URL 설정 (선택사항)
 val clientWithCustomUrl = DataGsmClient.builder("your-api-key-here")
-    .baseUrl("https://api.datagsm.com")  // 설정하지 않는다면 공식 Base URL 사용
+    .baseUrl("https://api.datagsm.com") // 설정하지 않는다면 공식 Base URL 사용
     .build()`} />
 
 </CodeTabs>


### PR DESCRIPTION
## 개요 💡

OpenAPI Java SDK의 버전이 변경되어 최신 버전을 따르도록 변경하였습니다.

## 작업내용 ⌨️

OpenAPI Java SDK의 버전을 `1.0.0`에서 최신 버전인 `1.1.0`으로 변경하였습니다.
또한, `BaseUrl` 파라미터를 설정하지 않았을 때의 동작을 주석을 통하여 조금 더 정확히 명시하였습니다.

## 스크린샷/동영상 📸

<img width="722" height="222" alt="image" src="https://github.com/user-attachments/assets/844093bd-43cc-4c58-9f3e-67df5d44355d" />

<img width="711" height="268" alt="image" src="https://github.com/user-attachments/assets/42f5c6d9-6ae4-45d4-8a78-e35de9520683" />

## 관련 이슈 🚨

- https://github.com/themoment-team/datagsm-openapi-sdk-java/releases/tag/1.1.0