### PR TITLE
feat: 비밀번호 재설정 기능 구현 및 회원가입 폼 개선

### DIFF
--- a/apps/admin/src/widgets/signin/ui/SignInForm/index.tsx
+++ b/apps/admin/src/widgets/signin/ui/SignInForm/index.tsx
@@ -12,7 +12,6 @@ import {
   getApiErrorCode,
   setCookie,
 } from '@repo/shared/utils';
-import { AxiosError } from 'axios';
 import { toast } from 'sonner';
 
 import { useRequestOAuthCode } from '../../model/useRequestOAuthCode';

--- a/apps/admin/src/widgets/signin/ui/SignInForm/index.tsx
+++ b/apps/admin/src/widgets/signin/ui/SignInForm/index.tsx
@@ -6,7 +6,12 @@ import { COOKIE_KEYS } from '@repo/shared/constants';
 import { useExchangeToken } from '@repo/shared/hooks';
 import { SignInFormType } from '@repo/shared/types';
 import { SignInForm as SharedSignInForm } from '@repo/shared/ui';
-import { generateCodeChallenge, generateCodeVerifier, setCookie } from '@repo/shared/utils';
+import {
+  generateCodeChallenge,
+  generateCodeVerifier,
+  getApiErrorCode,
+  setCookie,
+} from '@repo/shared/utils';
 import { AxiosError } from 'axios';
 import { toast } from 'sonner';
 
@@ -31,8 +36,7 @@ const SignInForm = () => {
       router.push('/students');
     },
     onError: (error: unknown) => {
-      const statusCode =
-        error instanceof AxiosError ? (error.response?.data as { code?: number })?.code : undefined;
+      const statusCode = getApiErrorCode(error);
 
       switch (statusCode) {
         case 400:
@@ -57,10 +61,7 @@ const SignInForm = () => {
         });
       },
       onError: (error: unknown) => {
-        const statusCode =
-          error instanceof AxiosError
-            ? (error.response?.data as { code?: number })?.code
-            : undefined;
+        const statusCode = getApiErrorCode(error);
 
         switch (statusCode) {
           case 400:

--- a/apps/client/src/app/signin/reset-password/page.tsx
+++ b/apps/client/src/app/signin/reset-password/page.tsx
@@ -1,0 +1,7 @@
+import { ResetPasswordPage } from '@/views/reset-password';
+
+const ResetPassword = () => {
+  return <ResetPasswordPage />;
+};
+
+export default ResetPassword;

--- a/apps/client/src/entities/reset-password/index.ts
+++ b/apps/client/src/entities/reset-password/index.ts
@@ -1,0 +1,1 @@
+export * from './model/schema';

--- a/apps/client/src/entities/reset-password/model/schema.ts
+++ b/apps/client/src/entities/reset-password/model/schema.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+export const ResetPasswordFormSchema = z
+  .object({
+    email: z
+      .string()
+      .min(1, { message: '이메일을 입력해주세요.' })
+      .pipe(z.email({ message: '올바른 이메일 형식이 아닙니다.' }))
+      .refine((email) => email.endsWith('@gsm.hs.kr'), {
+        message: '@gsm.hs.kr 도메인 계정만 사용 가능합니다.',
+      }),
+    code: z
+      .string()
+      .min(1, { message: '인증 코드를 입력해주세요.' })
+      .length(8, { message: '인증 코드는 8자리입니다.' }),
+    password: z
+      .string()
+      .min(1, { message: '비밀번호를 입력해주세요.' })
+      .min(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
+      .max(100, { message: '비밀번호는 최대 100자 이하여야 합니다.' })
+      .regex(/^(?=.*[a-zA-Z])(?=.*[0-9])/, {
+        message: '비밀번호는 영문과 숫자를 포함해야 합니다.',
+      }),
+    confirmPassword: z.string().min(1, { message: '비밀번호 확인을 입력해주세요.' }),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: '비밀번호가 일치하지 않습니다.',
+    path: ['confirmPassword'],
+  });
+
+export type ResetPasswordFormType = z.infer<typeof ResetPasswordFormSchema>;
+
+export type ChangePasswordRequestType = {
+  email: string;
+  code: string;
+  newPassword: string;
+};

--- a/apps/client/src/entities/signup/model/schema.ts
+++ b/apps/client/src/entities/signup/model/schema.ts
@@ -1,28 +1,35 @@
 import { z } from 'zod';
 
-export const SignUpFormSchema = z.object({
-  email: z
-    .string()
-    .min(1, { message: '이메일을 입력해주세요.' })
-    .pipe(z.email({ message: '올바른 이메일 형식이 아닙니다.' }))
-    .refine((email) => email.endsWith('@gsm.hs.kr'), {
-      message: '@gsm.hs.kr 도메인 계정만 사용 가능합니다.',
+export const SignUpFormSchema = z
+  .object({
+    email: z
+      .string()
+      .min(1, { message: '이메일을 입력해주세요.' })
+      .pipe(z.email({ message: '올바른 이메일 형식이 아닙니다.' }))
+      .refine((email) => email.endsWith('@gsm.hs.kr'), {
+        message: '@gsm.hs.kr 도메인 계정만 사용 가능합니다.',
+      }),
+    password: z
+      .string()
+      .min(1, { message: '비밀번호를 입력해주세요.' })
+      .min(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
+      .max(100, { message: '비밀번호는 최대 100자 이하여야 합니다.' })
+      .regex(/^(?=.*[a-zA-Z])(?=.*[0-9])/, {
+        message: '비밀번호는 영문과 숫자를 포함해야 합니다.',
+      }),
+    confirmPassword: z.string().min(1, { message: '비밀번호 확인을 입력해주세요.' }),
+    code: z
+      .string()
+      .min(1, { message: '인증 코드를 입력해주세요.' })
+      .length(8, { message: '인증 코드는 8자리입니다.' }),
+    privacyAgreed: z.boolean().refine((val) => val === true, {
+      message: '개인정보 처리방침에 동의해주세요.',
     }),
-  password: z
-    .string()
-    .min(1, { message: '비밀번호를 입력해주세요.' })
-    .min(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
-    .regex(/^(?=.*[a-zA-Z])(?=.*[0-9])/, {
-      message: '비밀번호는 영문과 숫자를 포함해야 합니다.',
-    }),
-  code: z
-    .string()
-    .min(1, { message: '인증 코드를 입력해주세요.' })
-    .length(8, { message: '인증 코드는 8자리입니다.' }),
-  privacyAgreed: z.boolean().refine((val) => val === true, {
-    message: '개인정보 처리방침에 동의해주세요.',
-  }),
-});
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: '비밀번호가 일치하지 않습니다.',
+    path: ['confirmPassword'],
+  });
 
 export type SignUpFormType = z.infer<typeof SignUpFormSchema>;
-export type SignUpRequestType = Omit<SignUpFormType, 'privacyAgreed'>;
+export type SignUpRequestType = Omit<SignUpFormType, 'privacyAgreed' | 'confirmPassword'>;

--- a/apps/client/src/middleware.ts
+++ b/apps/client/src/middleware.ts
@@ -17,7 +17,7 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  if (pathname === '/signup') {
+  if (pathname === '/signup' || pathname === '/signin/reset-password') {
     return NextResponse.next();
   }
 

--- a/apps/client/src/views/reset-password/index.ts
+++ b/apps/client/src/views/reset-password/index.ts
@@ -1,0 +1,1 @@
+export { default as ResetPasswordPage } from './ui/ResetPasswordPage';

--- a/apps/client/src/views/reset-password/ui/ResetPasswordPage/index.tsx
+++ b/apps/client/src/views/reset-password/ui/ResetPasswordPage/index.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@repo/shared/utils';
+
+import { ResetPasswordForm } from '@/widgets/reset-password';
+
+const ResetPasswordPage = () => {
+  return (
+    <div className={cn('bg-background flex min-h-screen items-center justify-center px-4')}>
+      <ResetPasswordForm />
+    </div>
+  );
+};
+
+export default ResetPasswordPage;

--- a/apps/client/src/views/signup/ui/SignUpPage/index.tsx
+++ b/apps/client/src/views/signup/ui/SignUpPage/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { cn } from '@repo/shared/utils';
 
 import { SignUpForm } from '@/widgets/signup';

--- a/apps/client/src/widgets/reset-password/index.ts
+++ b/apps/client/src/widgets/reset-password/index.ts
@@ -1,0 +1,4 @@
+export { default as ResetPasswordForm } from './ui/ResetPasswordForm';
+export * from './model/useChangePassword';
+export * from './model/useSendPasswordResetEmail';
+export * from './model/useVerifyPasswordResetCode';

--- a/apps/client/src/widgets/reset-password/model/useChangePassword.ts
+++ b/apps/client/src/widgets/reset-password/model/useChangePassword.ts
@@ -1,0 +1,19 @@
+import { accountQueryKeys, accountUrl, oauthPut } from '@repo/shared/api';
+import { BaseApiResponse } from '@repo/shared/types';
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { ChangePasswordRequestType } from '@/entities/reset-password';
+
+export const useChangePassword = (
+  options?: Omit<
+    UseMutationOptions<BaseApiResponse, AxiosError, ChangePasswordRequestType>,
+    'mutationKey' | 'mutationFn'
+  >,
+) =>
+  useMutation({
+    mutationKey: accountQueryKeys.putPassword(),
+    mutationFn: (data: ChangePasswordRequestType) =>
+      oauthPut<BaseApiResponse>(accountUrl.putPassword(), data),
+    ...options,
+  });

--- a/apps/client/src/widgets/reset-password/model/useSendPasswordResetEmail.ts
+++ b/apps/client/src/widgets/reset-password/model/useSendPasswordResetEmail.ts
@@ -1,0 +1,21 @@
+import { accountQueryKeys, accountUrl, oauthPost } from '@repo/shared/api';
+import { BaseApiResponse } from '@repo/shared/types';
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+interface SendPasswordResetEmailParams {
+  email: string;
+}
+
+export const useSendPasswordResetEmail = (
+  options?: Omit<
+    UseMutationOptions<BaseApiResponse, AxiosError, SendPasswordResetEmailParams>,
+    'mutationKey' | 'mutationFn'
+  >,
+) =>
+  useMutation({
+    mutationKey: accountQueryKeys.postPasswordReset(),
+    mutationFn: (data: SendPasswordResetEmailParams) =>
+      oauthPost<BaseApiResponse>(accountUrl.postPasswordReset(), data),
+    ...options,
+  });

--- a/apps/client/src/widgets/reset-password/model/useVerifyPasswordResetCode.ts
+++ b/apps/client/src/widgets/reset-password/model/useVerifyPasswordResetCode.ts
@@ -1,0 +1,22 @@
+import { accountQueryKeys, accountUrl, oauthPost } from '@repo/shared/api';
+import { BaseApiResponse } from '@repo/shared/types';
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+interface VerifyPasswordResetCodeParams {
+  email: string;
+  code: string;
+}
+
+export const useVerifyPasswordResetCode = (
+  options?: Omit<
+    UseMutationOptions<BaseApiResponse, AxiosError, VerifyPasswordResetCodeParams>,
+    'mutationKey' | 'mutationFn'
+  >,
+) =>
+  useMutation({
+    mutationKey: accountQueryKeys.postPasswordResetVerification(),
+    mutationFn: (data: VerifyPasswordResetCodeParams) =>
+      oauthPost<BaseApiResponse>(accountUrl.postPasswordResetVerification(), data),
+    ...options,
+  });

--- a/apps/client/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
+++ b/apps/client/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
@@ -19,7 +19,6 @@ import {
   Label,
 } from '@repo/shared/ui';
 import { cn, getApiErrorCode, minutesToMs } from '@repo/shared/utils';
-import { AxiosError } from 'axios';
 import { Database, Eye, EyeOff } from 'lucide-react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { toast } from 'sonner';

--- a/apps/client/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
+++ b/apps/client/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
@@ -178,8 +178,8 @@ const ResetPasswordForm = () => {
 
   const { mutate: changePassword, isPending: isSigningUp } = useChangePassword({
     onSuccess: () => {
-      router.push('/');
       toast.success('비밀번호가 변경되었습니다.');
+      setTimeout(() => router.push('/'), 1500);
     },
     onError: (error: unknown) => {
       const statusCode =

--- a/apps/client/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
+++ b/apps/client/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
@@ -1,0 +1,377 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  FormErrorMessage,
+  Input,
+  Label,
+} from '@repo/shared/ui';
+import { cn, minutesToMs } from '@repo/shared/utils';
+import { AxiosError } from 'axios';
+import { Database, Eye, EyeOff } from 'lucide-react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+
+import { ResetPasswordFormSchema, ResetPasswordFormType } from '@/entities/reset-password';
+import { useDebounce } from '@/shared/hooks';
+import {
+  useChangePassword,
+  useSendPasswordResetEmail,
+  useVerifyPasswordResetCode,
+} from '@/widgets/reset-password';
+
+const RESEND_COOLDOWN_MS = minutesToMs(5);
+const STORAGE_KEY = 'password_reset_verification_timestamp';
+
+const ResetPasswordForm = () => {
+  const [codeSent, setCodeSent] = useState(false);
+  const [isCodeVerified, setIsCodeVerified] = useState(false);
+  const [remainingTime, setRemainingTime] = useState(0);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const router = useRouter();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    getValues,
+    trigger,
+    watch,
+    setValue,
+  } = useForm<ResetPasswordFormType>({
+    resolver: zodResolver(ResetPasswordFormSchema),
+  });
+
+  const codeValue = watch('code');
+  const emailValue = watch('email');
+  const passwordValue = watch('password');
+  const confirmPasswordValue = watch('confirmPassword');
+  const debouncedCode = useDebounce(codeValue, 1000);
+  const lastCheckedCode = useRef('');
+  const hasShownExpiredToast = useRef(false);
+
+  const isFormValid = ResetPasswordFormSchema.safeParse({
+    email: emailValue,
+    password: passwordValue,
+    code: codeValue,
+    confirmPassword: confirmPasswordValue,
+  }).success;
+
+  // 페이지 로드 시 localStorage에서 마지막 전송 시간 확인
+  useEffect(() => {
+    const lastSentTime = localStorage.getItem(STORAGE_KEY);
+    if (lastSentTime) {
+      const elapsed = Date.now() - parseInt(lastSentTime, 10);
+      if (elapsed < RESEND_COOLDOWN_MS) {
+        setCodeSent(true);
+        setRemainingTime(Math.ceil((RESEND_COOLDOWN_MS - elapsed) / 1000));
+      } else {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    }
+  }, []);
+
+  // 남은 시간 카운트다운
+  useEffect(() => {
+    if (remainingTime > 0) {
+      const timer = setInterval(() => {
+        setRemainingTime((prev) => {
+          if (prev === 1) {
+            localStorage.removeItem(STORAGE_KEY);
+            setCodeSent(false);
+            setIsCodeVerified(false);
+            lastCheckedCode.current = '';
+            setValue('code', '');
+            if (!hasShownExpiredToast.current) {
+              hasShownExpiredToast.current = true;
+              toast.error('인증 시간이 만료되었습니다. 다시 인증해주세요.');
+            }
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+
+      return () => clearInterval(timer);
+    }
+  }, [remainingTime, setValue]);
+
+  const { mutate: sendEmailCode, isPending: isSendingCode } = useSendPasswordResetEmail({
+    onSuccess: () => {
+      const timestamp = Date.now();
+      localStorage.setItem(STORAGE_KEY, timestamp.toString());
+      setCodeSent(true);
+      setRemainingTime(RESEND_COOLDOWN_MS / 1000);
+      hasShownExpiredToast.current = false;
+      toast.success('인증 코드가 이메일로 전송되었습니다.');
+    },
+    onError: (error: unknown) => {
+      const statusCode =
+        error instanceof AxiosError ? (error.response?.data as { code?: number })?.code : undefined;
+
+      switch (statusCode) {
+        case 404:
+          toast.error('존재하지 않는 이메일입니다.');
+          break;
+        case 429:
+          toast.error('요청 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.');
+          break;
+        default:
+          toast.error('인증 코드 전송에 실패했습니다.');
+      }
+    },
+  });
+
+  const { mutate: checkEmailCode } = useVerifyPasswordResetCode({
+    onSuccess: () => {
+      setIsCodeVerified(true);
+      toast.success('인증 코드가 확인되었습니다.');
+    },
+    onError: (error: unknown) => {
+      const statusCode =
+        error instanceof AxiosError ? (error.response?.data as { code?: number })?.code : undefined;
+
+      switch (statusCode) {
+        case 400:
+          setIsCodeVerified(false);
+          toast.error('인증 코드가 일치하지 않습니다.');
+          break;
+        case 404:
+          setIsCodeVerified(false);
+          toast.error('인증 코드가 만료되었거나 존재하지 않습니다.');
+          break;
+        case 429:
+          setIsCodeVerified(false);
+          toast.error('요청 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.');
+          break;
+        default:
+          setIsCodeVerified(false);
+          toast.error('인증 코드 확인에 실패했습니다.');
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (
+      codeSent &&
+      debouncedCode &&
+      debouncedCode.length === 8 &&
+      lastCheckedCode.current !== debouncedCode
+    ) {
+      lastCheckedCode.current = debouncedCode;
+      checkEmailCode({ email: emailValue, code: debouncedCode });
+    }
+  }, [codeSent, debouncedCode, emailValue, checkEmailCode]);
+
+  const { mutate: changePassword, isPending: isSigningUp } = useChangePassword({
+    onSuccess: () => {
+      router.push('/');
+      toast.success('비밀번호가 변경되었습니다.');
+    },
+    onError: (error: unknown) => {
+      const statusCode =
+        error instanceof AxiosError ? (error.response?.data as { code?: number })?.code : undefined;
+
+      switch (statusCode) {
+        case 400:
+          toast.error('이전 비밀번호와 동일합니다.');
+          break;
+        case 404:
+          toast.error('계정이 존재하지 않습니다.');
+          break;
+        case 429:
+          toast.error('요청 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.');
+          break;
+        default:
+          toast.error('비밀번호 변경에 실패했습니다.');
+      }
+    },
+  });
+
+  const handleSendCode = async () => {
+    const isEmailValid = await trigger('email');
+    if (!isEmailValid) return;
+
+    const email = getValues('email');
+    sendEmailCode({ email });
+  };
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  const canResend = remainingTime === 0;
+  const isButtonDisabled =
+    isSendingCode || !emailValue || (codeSent && !canResend) || isCodeVerified;
+
+  const onSubmit: SubmitHandler<ResetPasswordFormType> = (data) => {
+    if (!isCodeVerified) {
+      toast.error('이메일 인증을 완료해주세요.');
+      return;
+    }
+    const { email, code, password } = data;
+    changePassword({ email, code, newPassword: password });
+  };
+
+  return (
+    <Card className={cn('w-full max-w-md')}>
+      <CardHeader className={cn('space-y-4 text-center')}>
+        <div
+          className={cn(
+            'bg-primary/10 mx-auto inline-flex h-16 w-16 items-center justify-center rounded-full',
+          )}
+        >
+          <Database className={cn('text-primary h-8 w-8')} />
+        </div>
+        <div>
+          <CardTitle className={cn('text-3xl')}>비밀번호 재설정</CardTitle>
+          <CardDescription className={cn('mt-2')}>새로운 비밀번호를 설정하세요</CardDescription>
+        </div>
+      </CardHeader>
+
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <CardContent className={cn('space-y-4')}>
+          <div className={cn('space-y-2')}>
+            <Label htmlFor="email">이메일</Label>
+            <div className={cn('flex gap-2')}>
+              <div className={cn('flex-1 space-y-2')}>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="example@gsm.hs.kr"
+                  {...register('email')}
+                  disabled={remainingTime > 0 || isCodeVerified}
+                />
+                <FormErrorMessage error={errors.email} />
+              </div>
+              <Button
+                type="button"
+                onClick={handleSendCode}
+                className={cn('whitespace-nowrap', isButtonDisabled && 'cursor-not-allowed')}
+                disabled={isButtonDisabled}
+              >
+                {isSendingCode
+                  ? '전송 중...'
+                  : codeSent && !canResend
+                    ? `재전송 (${formatTime(remainingTime)})`
+                    : codeSent && canResend
+                      ? '재전송'
+                      : '인증 코드'}
+              </Button>
+            </div>
+            <div className={cn('space-y-2', !codeSent && 'cursor-not-allowed')}>
+              <Input
+                id="code"
+                type="text"
+                placeholder="메일로 받은 인증 코드를 입력하세요"
+                {...register('code')}
+                disabled={!codeSent || isCodeVerified}
+              />
+              {isCodeVerified && (
+                <p className={cn('text-sm text-green-600')}>인증 코드가 확인되었습니다.</p>
+              )}
+              {!isCodeVerified && <FormErrorMessage error={errors.code} />}
+            </div>
+          </div>
+
+          <div className={cn('space-y-2')}>
+            <Label htmlFor="password">새 비밀번호</Label>
+            <div className={cn('flex gap-2')}>
+              <div className={cn('relative flex-1')}>
+                <Input
+                  id="password"
+                  type={showPassword ? 'text' : 'password'}
+                  placeholder="새 비밀번호를 입력하세요"
+                  {...register('password')}
+                  disabled={!isCodeVerified || isSigningUp}
+                  className={cn('pr-10')}
+                />
+                <button
+                  type="button"
+                  aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+                  onClick={() => setShowPassword(!showPassword)}
+                  className={cn(
+                    'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
+                    (!isCodeVerified || isSigningUp) && 'cursor-not-allowed opacity-50',
+                  )}
+                  disabled={!isCodeVerified || isSigningUp}
+                >
+                  {showPassword ? (
+                    <EyeOff className={cn('h-4 w-4')} />
+                  ) : (
+                    <Eye className={cn('h-4 w-4')} />
+                  )}
+                </button>
+              </div>
+            </div>
+            <FormErrorMessage error={errors.password} />
+            <div className={cn('relative')}>
+              <Input
+                id="confirmPassword"
+                type={showConfirmPassword ? 'text' : 'password'}
+                placeholder="비밀번호를 다시 입력하세요"
+                {...register('confirmPassword')}
+                disabled={!isCodeVerified || isSigningUp}
+                className={cn('pr-10')}
+              />
+              <button
+                type="button"
+                aria-label={showConfirmPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                className={cn(
+                  'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
+                  (!isCodeVerified || isSigningUp) && 'cursor-not-allowed opacity-50',
+                )}
+                disabled={!isCodeVerified || isSigningUp}
+              >
+                {showConfirmPassword ? (
+                  <EyeOff className={cn('h-4 w-4')} />
+                ) : (
+                  <Eye className={cn('h-4 w-4')} />
+                )}
+              </button>
+            </div>
+            <FormErrorMessage error={errors.confirmPassword} />
+          </div>
+        </CardContent>
+
+        <CardFooter className={cn('mt-6 flex flex-col space-y-4')}>
+          <Button
+            type="submit"
+            className={cn(
+              'w-full',
+              (isSigningUp || !isCodeVerified || !isFormValid) && 'cursor-not-allowed',
+            )}
+            size="lg"
+            disabled={isSigningUp || !isCodeVerified || !isFormValid}
+          >
+            {isSigningUp ? '처리 중...' : '비밀번호 재설정'}
+          </Button>
+
+          <p className="text-muted-foreground text-center text-sm">
+            <Link href="/signin" className="text-primary font-medium hover:underline">
+              로그인으로 돌아가기
+            </Link>
+          </p>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+};
+
+export default ResetPasswordForm;

--- a/apps/client/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
+++ b/apps/client/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
@@ -92,12 +92,15 @@ const ResetPasswordForm = () => {
           if (prev === 1) {
             localStorage.removeItem(STORAGE_KEY);
             setCodeSent(false);
-            setIsCodeVerified(false);
-            lastCheckedCode.current = '';
-            setValue('code', '');
-            if (!hasShownExpiredToast.current) {
-              hasShownExpiredToast.current = true;
-              toast.error('인증 시간이 만료되었습니다. 다시 인증해주세요.');
+
+            if (!isCodeVerified) {
+              setIsCodeVerified(false);
+              lastCheckedCode.current = '';
+              setValue('code', '');
+              if (!hasShownExpiredToast.current) {
+                hasShownExpiredToast.current = true;
+                toast.error('인증 시간이 만료되었습니다. 다시 인증해주세요.');
+              }
             }
             return 0;
           }
@@ -107,7 +110,7 @@ const ResetPasswordForm = () => {
 
       return () => clearInterval(timer);
     }
-  }, [remainingTime, setValue]);
+  }, [remainingTime, setValue, isCodeVerified]);
 
   const { mutate: sendEmailCode, isPending: isSendingCode } = useSendPasswordResetEmail({
     onSuccess: () => {

--- a/apps/client/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
+++ b/apps/client/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
@@ -18,7 +18,7 @@ import {
   Input,
   Label,
 } from '@repo/shared/ui';
-import { cn, minutesToMs } from '@repo/shared/utils';
+import { cn, getApiErrorCode, minutesToMs } from '@repo/shared/utils';
 import { AxiosError } from 'axios';
 import { Database, Eye, EyeOff } from 'lucide-react';
 import { SubmitHandler, useForm } from 'react-hook-form';
@@ -119,8 +119,7 @@ const ResetPasswordForm = () => {
       toast.success('인증 코드가 이메일로 전송되었습니다.');
     },
     onError: (error: unknown) => {
-      const statusCode =
-        error instanceof AxiosError ? (error.response?.data as { code?: number })?.code : undefined;
+      const statusCode = getApiErrorCode(error);
 
       switch (statusCode) {
         case 404:
@@ -141,8 +140,7 @@ const ResetPasswordForm = () => {
       toast.success('인증 코드가 확인되었습니다.');
     },
     onError: (error: unknown) => {
-      const statusCode =
-        error instanceof AxiosError ? (error.response?.data as { code?: number })?.code : undefined;
+      const statusCode = getApiErrorCode(error);
 
       switch (statusCode) {
         case 400:
@@ -182,8 +180,7 @@ const ResetPasswordForm = () => {
       setTimeout(() => router.push('/'), 1500);
     },
     onError: (error: unknown) => {
-      const statusCode =
-        error instanceof AxiosError ? (error.response?.data as { code?: number })?.code : undefined;
+      const statusCode = getApiErrorCode(error);
 
       switch (statusCode) {
         case 400:

--- a/apps/client/src/widgets/signup/ui/SignUpForm/index.tsx
+++ b/apps/client/src/widgets/signup/ui/SignUpForm/index.tsx
@@ -126,12 +126,15 @@ const SignUpForm = () => {
           if (prev === 1) {
             localStorage.removeItem(STORAGE_KEY);
             setCodeSent(false);
-            setIsCodeVerified(false);
-            lastCheckedCode.current = '';
-            setValue('code', '');
-            if (!hasShownExpiredToast.current) {
-              hasShownExpiredToast.current = true;
-              toast.error('인증 시간이 만료되었습니다. 다시 인증해주세요.');
+
+            if (!isCodeVerified) {
+              setIsCodeVerified(false);
+              lastCheckedCode.current = '';
+              setValue('code', '');
+              if (!hasShownExpiredToast.current) {
+                hasShownExpiredToast.current = true;
+                toast.error('인증 시간이 만료되었습니다. 다시 인증해주세요.');
+              }
             }
             return 0;
           }
@@ -141,7 +144,7 @@ const SignUpForm = () => {
 
       return () => clearInterval(timer);
     }
-  }, [remainingTime, setValue]);
+  }, [remainingTime, setValue, isCodeVerified]);
 
   const { mutate: sendEmailCode, isPending: isSendingCode } = useSendEmailCode({
     onSuccess: () => {

--- a/apps/client/src/widgets/signup/ui/SignUpForm/index.tsx
+++ b/apps/client/src/widgets/signup/ui/SignUpForm/index.tsx
@@ -19,8 +19,7 @@ import {
   Label,
 } from '@repo/shared/ui';
 import { Checkbox, Dialog, DialogContent, DialogHeader, DialogTitle } from '@repo/shared/ui';
-import { cn, minutesToMs } from '@repo/shared/utils';
-import { AxiosError } from 'axios';
+import { cn, getApiErrorCode, minutesToMs } from '@repo/shared/utils';
 import { Database, Eye, EyeOff } from 'lucide-react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -154,8 +153,7 @@ const SignUpForm = () => {
       toast.success('인증 코드가 이메일로 전송되었습니다.');
     },
     onError: (error: unknown) => {
-      const statusCode =
-        error instanceof AxiosError ? (error.response?.data as { code?: number })?.code : undefined;
+      const statusCode = getApiErrorCode(error);
 
       switch (statusCode) {
         case 400:
@@ -176,8 +174,7 @@ const SignUpForm = () => {
       toast.success('인증 코드가 확인되었습니다.');
     },
     onError: (error: unknown) => {
-      const statusCode =
-        error instanceof AxiosError ? (error.response?.data as { code?: number })?.code : undefined;
+      const statusCode = getApiErrorCode(error);
 
       switch (statusCode) {
         case 400:
@@ -213,8 +210,7 @@ const SignUpForm = () => {
       setTimeout(() => router.push('/'), 1500);
     },
     onError: (error: unknown) => {
-      const statusCode =
-        error instanceof AxiosError ? (error.response?.data as { code?: number })?.code : undefined;
+      const statusCode = getApiErrorCode(error);
 
       switch (statusCode) {
         case 400:

--- a/apps/client/src/widgets/signup/ui/SignUpForm/index.tsx
+++ b/apps/client/src/widgets/signup/ui/SignUpForm/index.tsx
@@ -41,6 +41,7 @@ const SignUpForm = () => {
   const [isPrivacyDialogOpen, setIsPrivacyDialogOpen] = useState(false);
   const [hasScrolledToBottom, setHasScrolledToBottom] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
 
@@ -59,6 +60,7 @@ const SignUpForm = () => {
   const codeValue = watch('code');
   const emailValue = watch('email');
   const passwordValue = watch('password');
+  const confirmPasswordValue = watch('confirmPassword');
   const privacyAgreedValue = watch('privacyAgreed');
   const debouncedCode = useDebounce(codeValue, 1000);
   const lastCheckedCode = useRef('');
@@ -67,6 +69,7 @@ const SignUpForm = () => {
   const isFormValid = SignUpFormSchema.safeParse({
     email: emailValue,
     password: passwordValue,
+    confirmPassword: confirmPasswordValue,
     code: codeValue,
     privacyAgreed: privacyAgreedValue,
   }).success;
@@ -327,7 +330,7 @@ const SignUpForm = () => {
                 type={showPassword ? 'text' : 'password'}
                 placeholder="비밀번호를 입력하세요"
                 {...register('password')}
-                disabled={isSigningUp}
+                disabled={!isCodeVerified || isSigningUp}
                 className={cn('pr-10')}
               />
               <button
@@ -336,9 +339,9 @@ const SignUpForm = () => {
                 onClick={() => setShowPassword(!showPassword)}
                 className={cn(
                   'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
-                  isSigningUp && 'cursor-not-allowed opacity-50',
+                  (!isCodeVerified || isSigningUp) && 'cursor-not-allowed opacity-50',
                 )}
-                disabled={isSigningUp}
+                disabled={!isCodeVerified || isSigningUp}
               >
                 {showPassword ? (
                   <EyeOff className={cn('h-4 w-4')} />
@@ -348,6 +351,33 @@ const SignUpForm = () => {
               </button>
             </div>
             <FormErrorMessage error={errors.password} />
+            <div className={cn('relative')}>
+              <Input
+                id="confirmPassword"
+                type={showConfirmPassword ? 'text' : 'password'}
+                placeholder="비밀번호를 다시 입력하세요"
+                {...register('confirmPassword')}
+                disabled={!isCodeVerified || isSigningUp}
+                className={cn('pr-10')}
+              />
+              <button
+                type="button"
+                aria-label={showConfirmPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                className={cn(
+                  'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
+                  (!isCodeVerified || isSigningUp) && 'cursor-not-allowed opacity-50',
+                )}
+                disabled={!isCodeVerified || isSigningUp}
+              >
+                {showConfirmPassword ? (
+                  <EyeOff className={cn('h-4 w-4')} />
+                ) : (
+                  <Eye className={cn('h-4 w-4')} />
+                )}
+              </button>
+            </div>
+            <FormErrorMessage error={errors.confirmPassword} />
           </div>
 
           <div className={cn('flex items-center space-x-2')}>

--- a/apps/client/src/widgets/signup/ui/SignUpForm/index.tsx
+++ b/apps/client/src/widgets/signup/ui/SignUpForm/index.tsx
@@ -207,7 +207,7 @@ const SignUpForm = () => {
   const { mutate: signUp, isPending: isSigningUp } = useSignUp({
     onSuccess: () => {
       toast.success('회원가입이 완료되었습니다. 로그인해주세요.');
-      router.push('/');
+      setTimeout(() => router.push('/'), 1500);
     },
     onError: (error: unknown) => {
       const statusCode =

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,123 +9,15 @@
   ],
   "exports": {
     "./styles/globals.css": "./dist/styles/globals.css",
-    "./ui": {
-      "types": "./dist/ui/index.d.ts",
-      "default": "./dist/ui/index.js"
-    },
-    "./ui/*": {
-      "types": "./src/ui/*.ts",
-      "default": "./dist/ui/*.js"
-    },
-    "./assets": {
-      "types": "./dist/assets/index.d.ts",
-      "default": "./dist/assets/index.js"
-    },
-    "./assets/*": {
-      "types": "./src/assets/*.ts",
-      "default": "./dist/assets/*.js"
-    },
-    "./api": {
-      "types": "./dist/api/index.d.ts",
-      "default": "./dist/api/index.js"
-    },
-    "./api/*": {
-      "types": "./src/api/*.ts",
-      "default": "./dist/api/*.js"
-    },
-    "./types": {
-      "types": "./dist/types/index.d.ts",
-      "default": "./dist/types/index.js"
-    },
-    "./types/*": {
-      "types": "./src/types/*.ts",
-      "default": "./dist/types/*.js"
-    },
-    "./lib": {
-      "types": "./dist/lib/index.d.ts",
-      "default": "./dist/lib/index.js"
-    },
-    "./lib/*": {
-      "types": "./src/lib/*.ts",
-      "default": "./dist/lib/*.js"
-    },
-    "./utils": {
-      "types": "./dist/utils/index.d.ts",
-      "default": "./dist/utils/index.js"
-    },
-    "./utils/*": {
-      "types": "./src/utils/*.ts",
-      "default": "./dist/utils/*.js"
-    },
-    "./constants": {
-      "types": "./dist/constants/index.d.ts",
-      "default": "./dist/constants/index.js"
-    },
-    "./constants/*": {
-      "types": "./src/constants/*.ts",
-      "default": "./dist/constants/*.js"
-    },
-    "./hooks": {
-      "types": "./dist/hooks/index.d.ts",
-      "default": "./dist/hooks/index.js"
-    },
-    "./hooks/*": {
-      "types": "./dist/hooks/*.d.ts",
-      "default": "./dist/hooks/*.js"
-    }
+    "./api": "./src/api/index.ts",
+    "./assets": "./src/assets/index.ts",
+    "./constants": "./src/constants/index.ts",
+    "./hooks": "./src/hooks/index.ts",
+    "./lib": "./src/lib/index.ts",
+    "./types": "./src/types/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./utils": "./src/utils/index.ts"
   },
-  "typesVersions": {
-  "*": {
-    "ui": [
-      "./dist/ui/index.d.ts"
-    ],
-    "ui/*": [
-      "./src/ui/*"
-    ],
-    "assets": [
-      "./dist/assets/index.d.ts"
-    ],
-    "assets/*": [
-      "./src/assets/*"
-    ],
-    "api": [
-      "./dist/api/index.d.ts"
-    ],
-    "api/*": [
-      "./src/api/*"
-    ],
-    "types": [
-      "./dist/types/index.d.ts"
-    ],
-    "types/*": [
-      "./src/types/*"
-    ],
-    "lib": [
-      "./dist/lib/index.d.ts"
-    ],
-    "lib/*": [
-      "./src/lib/*"
-    ],
-    "utils": [
-      "./dist/utils/index.d.ts"
-    ],
-    "utils/*": [
-      "./src/utils/*"
-    ],
-    "constants": [
-      "./dist/constants/index.d.ts"
-    ],
-    "constants/*": [
-      "./src/constants/*"
-    ],
-    "hooks": [
-      "./dist/hooks/index.d.ts"
-    ],
-    "hooks/*": [
-      "./src/hooks/*"
-    ]
-  }
-},
   "license": "MIT",
   "scripts": {
     "build": "pnpm run build:components && pnpm run build:styles",

--- a/packages/shared/src/api/apiUrls.ts
+++ b/packages/shared/src/api/apiUrls.ts
@@ -119,9 +119,9 @@ export const accountUrl = {
   postEmailVerificationVerify: () => '/v1/accounts/email-verifications/verify',
   postAccount: () => '/v1/accounts',
   getMy: () => '/v1/accounts/my',
-  postPasswordReset: () => '/v1/accounts/password-resets',
-  postPasswordResetVerification: () => '/v1/accounts/password-resets/verification',
-  putPassword: () => '/v1/accounts/password',
+  postPasswordReset: () => '/v1/accounts/password-resets', // 비밀번호 재설정 요청 (이메일 발송)
+  postPasswordResetVerification: () => '/v1/accounts/password-resets/verification', // 비밀번호 재설정 코드 검증
+  putPassword: () => '/v1/accounts/password', // 비밀번호 변경 (인증된 사용자)
 } as const;
 
 export const oauthUrl = {

--- a/packages/shared/src/api/http.ts
+++ b/packages/shared/src/api/http.ts
@@ -17,3 +17,6 @@ export const put = async <T>(...args: Parameters<typeof axiosInstance.put>) =>
 
 export const oauthPost = async <T>(...args: Parameters<typeof oauthAxiosInstance.post>) =>
   await oauthAxiosInstance.post<T, T>(...args);
+
+export const oauthPut = async <T>(...args: Parameters<typeof oauthAxiosInstance.put>) =>
+  await oauthAxiosInstance.put<T, T>(...args);

--- a/packages/shared/src/ui/SignInForm/index.tsx
+++ b/packages/shared/src/ui/SignInForm/index.tsx
@@ -114,12 +114,22 @@ const SignInForm = ({ onSubmit, isPending = false, signupHref }: SignInFormProps
           </Button>
 
           {signupHref && (
-            <p className={cn('text-muted-foreground text-center text-sm')}>
-              계정이 없으신가요?{' '}
-              <Link href={signupHref} className={cn('text-primary font-medium hover:underline')}>
-                회원가입
-              </Link>
-            </p>
+            <div className="space-y-2 text-center text-sm">
+              <p className={cn('text-muted-foreground text-center text-sm')}>
+                계정이 없으신가요?{' '}
+                <Link href={signupHref} className={cn('text-primary font-medium hover:underline')}>
+                  회원가입
+                </Link>
+              </p>
+              <p>
+                <Link
+                  href="/signin/reset-password"
+                  className="text-muted-foreground hover:text-primary hover:underline"
+                >
+                  비밀번호를 잊으셨나요?
+                </Link>
+              </p>
+            </div>
           )}
         </CardFooter>
       </form>

--- a/packages/shared/src/utils/error.ts
+++ b/packages/shared/src/utils/error.ts
@@ -1,0 +1,8 @@
+import { AxiosError } from 'axios';
+
+export const getApiErrorCode = (error: unknown): number | undefined => {
+  if (error instanceof AxiosError) {
+    return (error.response?.data as { code?: number })?.code;
+  }
+  return undefined;
+};

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './cn';
 export * from './cookies';
 export * from './date';
+export * from './error';
 export * from './pkce';


### PR DESCRIPTION
## 개요 💡

Swagger API 문서를 기반으로 비밀번호 재설정 기능을 구현하고,
기존 회원가입 폼의 UX를 개선했습니다.

## 작업내용 ⌨️

**비밀번호 재설정 기능 구현**
- `entities/reset-password` — Zod 스키마, 폼 타입, API 요청 타입 정의
- `useSendPasswordResetEmail` — `POST /v1/accounts/password-resets`
- `useVerifyPasswordResetCode` — `POST /v1/accounts/password-resets/verification`
- `useChangePassword` — `PUT /v1/accounts/password`
- `shared/api/http.ts` — `oauthPut` 유틸 추가
- `/signin/reset-password` 라우트 및 페이지 생성
- 미들웨어에 비밀번호 재설정 페이지 인증 예외 처리 추가

**SignInForm 개선**
- 로그인 폼 하단에 "비밀번호를 잊으셨나요?" 링크 추가

**회원가입 폼 개선**
- 비밀번호 확인 필드 추가 (비밀번호 일치 검증)
- 이메일 인증 완료 전 비밀번호 필드 비활성화
- 성공 후 토스트 표시 → 1.5초 뒤 페이지 이동

**공통 UX 개선**
- 비밀번호 / 비밀번호 확인 토글 상태 분리 (각각 독립적으로 동작)
- 비밀번호 재설정도 성공 후 토스트 표시 → 1.5초 뒤 이동

## 스크린샷/동영상 📸

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/269c3f01-6752-4913-a699-79f6e9bb656a" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/2680de69-99cf-4204-88b7-1ad3c3002059" />