### PR TITLE
feat: OAuth 클라이언트에 serviceName 필드 추가 및 UI 반영

### DIFF
--- a/apps/client/src/entities/clients/model/schema.ts
+++ b/apps/client/src/entities/clients/model/schema.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 
 export const ClientFormSchema = z.object({
-  name: z.string().min(1, { message: '클라이언트 이름을 입력해주세요.' }),
+  clientName: z.string().min(1, { message: '클라이언트 이름을 입력해주세요.' }),
+  serviceName: z.string().min(1, { message: '서비스 명칭을 입력해주세요.' }),
   redirectUrls: z
     .array(
       z.object({

--- a/apps/client/src/entities/clients/model/types.ts
+++ b/apps/client/src/entities/clients/model/types.ts
@@ -2,7 +2,8 @@ import { ApiResponse } from '@repo/shared/types';
 
 export interface Client {
   id: string;
-  name: string;
+  clientName: string;
+  serviceName: string;
   redirectUrl: string[];
   scopes: string[];
 }
@@ -16,7 +17,8 @@ export interface ClientListData {
 export type ClientListResponse = ApiResponse<ClientListData>;
 
 export interface CreateClientRequest {
-  name: string;
+  clientName: string;
+  serviceName: string;
   scopes: string[];
   redirectUrls: string[];
 }
@@ -24,20 +26,24 @@ export interface CreateClientRequest {
 export interface CreateClientData {
   clientId: string;
   clientSecret: string;
-  name: string;
+  clientName: string;
+  serviceName: string;
   redirectUrls: string[];
+  scopes: string[];
 }
 
 export type CreateClientResponse = ApiResponse<CreateClientData>;
 
 export interface UpdateClientRequest {
-  name: string;
-  redirectUrls: string[];
+  clientName?: string;
+  serviceName?: string;
+  redirectUrls?: string[];
 }
 
 export interface UpdateClientData {
   id: string;
-  name: string;
+  clientName: string;
+  serviceName: string;
   redirectUrl: string[];
   scopes: string[];
 }

--- a/apps/client/src/widgets/clients/ui/ClientFormDialog/index.tsx
+++ b/apps/client/src/widgets/clients/ui/ClientFormDialog/index.tsx
@@ -85,7 +85,8 @@ const ClientFormDialog = ({
   } = useForm<ClientFormType>({
     resolver: zodResolver(ClientFormSchema),
     defaultValues: {
-      name: '',
+      clientName: '',
+      serviceName: '',
       redirectUrls: [{ url: '' }],
       scopes: [],
     },
@@ -108,13 +109,15 @@ const ClientFormDialog = ({
 
     if (mode === 'edit' && client) {
       reset({
-        name: client.name,
+        clientName: client.clientName,
+        serviceName: client.serviceName,
         redirectUrls: client.redirectUrl.map((url) => ({ url })),
         scopes: [...client.scopes],
       });
     } else if (mode === 'create') {
       reset({
-        name: '',
+        clientName: '',
+        serviceName: '',
         redirectUrls: [{ url: '' }],
         scopes: [],
       });
@@ -122,17 +125,21 @@ const ClientFormDialog = ({
   }, [mode, client, open, reset]);
 
   const onSubmit = (data: ClientFormType) => {
-    const formattedData = {
-      ...data,
-      redirectUrls: data.redirectUrls.map((item) => item.url),
-    };
-
     if (mode === 'create') {
-      createClient(formattedData);
+      createClient({
+        clientName: data.clientName,
+        serviceName: data.serviceName,
+        scopes: data.scopes,
+        redirectUrls: data.redirectUrls.map((item) => item.url),
+      });
     } else if (mode === 'edit' && client) {
       updateClient({
         clientId: client.id,
-        data: formattedData,
+        data: {
+          clientName: data.clientName,
+          serviceName: data.serviceName,
+          redirectUrls: data.redirectUrls.map((item) => item.url),
+        },
       });
     }
   };
@@ -176,9 +183,19 @@ const ClientFormDialog = ({
         </DialogHeader>
         <form onSubmit={handleSubmit(onSubmit)} className={cn('space-y-4 py-4')}>
           <div className={cn('space-y-2')}>
-            <Label htmlFor="name">클라이언트 이름</Label>
-            <Input id="name" placeholder="클라이언트 이름 입력" {...register('name')} />
-            <FormErrorMessage error={errors.name} />
+            <Label htmlFor="clientName">클라이언트 이름</Label>
+            <Input id="clientName" placeholder="클라이언트 이름 입력" {...register('clientName')} />
+            <FormErrorMessage error={errors.clientName} />
+          </div>
+
+          <div className={cn('space-y-2')}>
+            <Label htmlFor="serviceName">서비스 명칭</Label>
+            <Input
+              id="serviceName"
+              placeholder="로그인 페이지에 노출될 서비스 명칭 입력"
+              {...register('serviceName')}
+            />
+            <FormErrorMessage error={errors.serviceName} />
           </div>
 
           {mode === 'edit' && client && (

--- a/apps/client/src/widgets/clients/ui/ClientFormDialog/index.tsx
+++ b/apps/client/src/widgets/clients/ui/ClientFormDialog/index.tsx
@@ -125,12 +125,12 @@ const ClientFormDialog = ({
   }, [mode, client, open, reset]);
 
   const onSubmit = (data: ClientFormType) => {
+    const redirectUrls = data.redirectUrls.map((item) => item.url);
+
     if (mode === 'create') {
       createClient({
-        clientName: data.clientName,
-        serviceName: data.serviceName,
-        scopes: data.scopes,
-        redirectUrls: data.redirectUrls.map((item) => item.url),
+        ...data,
+        redirectUrls,
       });
     } else if (mode === 'edit' && client) {
       updateClient({
@@ -138,7 +138,7 @@ const ClientFormDialog = ({
         data: {
           clientName: data.clientName,
           serviceName: data.serviceName,
-          redirectUrls: data.redirectUrls.map((item) => item.url),
+          redirectUrls,
         },
       });
     }

--- a/apps/client/src/widgets/clients/ui/ClientList/index.tsx
+++ b/apps/client/src/widgets/clients/ui/ClientList/index.tsx
@@ -48,7 +48,8 @@ const ClientListItem = ({ client, onEdit, onDelete }: ClientListItemProps) => {
 
   return (
     <TableRow>
-      <TableCell className={cn('font-medium')}>{client.name}</TableCell>
+      <TableCell className={cn('font-medium')}>{client.clientName}</TableCell>
+      <TableCell>{client.serviceName}</TableCell>
       <TableCell>
         <div className={cn('flex items-center gap-2')}>
           <code className={cn('bg-muted rounded px-2 py-1 font-mono text-xs')}>{client.id}</code>
@@ -99,8 +100,8 @@ const ClientListItem = ({ client, onEdit, onDelete }: ClientListItemProps) => {
               <AlertDialogHeader>
                 <AlertDialogTitle>클라이언트 삭제</AlertDialogTitle>
                 <AlertDialogDescription>
-                  정말로 &apos;{client.name}&apos; 클라이언트를 삭제하시겠습니까? 이 작업은 되돌릴
-                  수 없습니다.
+                  정말로 &apos;{client.clientName}&apos; 클라이언트를 삭제하시겠습니까? 이 작업은
+                  되돌릴 수 없습니다.
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
@@ -141,10 +142,11 @@ const ClientList = ({ clients, isLoading, onEdit }: ClientListProps) => {
         <TableHeader>
           <TableRow>
             <TableHead>클라이언트 이름</TableHead>
+            <TableHead>서비스 명칭</TableHead>
             <TableHead>클라이언트 ID</TableHead>
             <TableHead>리다이렉트 URL</TableHead>
             <TableHead>권한 범위</TableHead>
-            <TableHead className={cn('w-[100px]')}>작업</TableHead>
+            <TableHead className={cn('w-25')}>작업</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -153,6 +155,9 @@ const ClientList = ({ clients, isLoading, onEdit }: ClientListProps) => {
               <TableRow key={index}>
                 <TableCell>
                   <Skeleton className={cn('h-4 w-32')} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className={cn('h-4 w-24')} />
                 </TableCell>
                 <TableCell>
                   <Skeleton className={cn('h-6 w-48')} />
@@ -179,7 +184,7 @@ const ClientList = ({ clients, isLoading, onEdit }: ClientListProps) => {
             ))
           ) : (
             <TableRow>
-              <TableCell colSpan={5} className={cn('h-24 text-center')}>
+              <TableCell colSpan={6} className={cn('h-24 text-center')}>
                 등록된 클라이언트가 없습니다.
               </TableCell>
             </TableRow>

--- a/apps/client/src/widgets/clients/ui/ClientSuccessDialog/index.tsx
+++ b/apps/client/src/widgets/clients/ui/ClientSuccessDialog/index.tsx
@@ -55,7 +55,12 @@ const ClientSuccessDialog = ({ open, onOpenChange, client }: ClientSuccessDialog
           <div className={cn('space-y-3')}>
             <div className={cn('space-y-1.5')}>
               <Label className={cn('text-muted-foreground text-xs')}>클라이언트 이름</Label>
-              <p className={cn('font-medium')}>{client.name}</p>
+              <p className={cn('font-medium')}>{client.clientName}</p>
+            </div>
+
+            <div className={cn('space-y-1.5')}>
+              <Label className={cn('text-muted-foreground text-xs')}>서비스 명칭</Label>
+              <p className={cn('font-medium')}>{client.serviceName}</p>
             </div>
 
             <div className={cn('space-y-1.5')}>

--- a/apps/client/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
+++ b/apps/client/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
 import { useState } from 'react';
+
+import { useSearchParams } from 'next/navigation';
 
 import { SignInFormType } from '@repo/shared/types';
 import { SignInForm as SharedSignInForm } from '@repo/shared/ui';
@@ -11,6 +12,7 @@ const OAuthAuthorizeForm = () => {
   const [isPending, setIsPending] = useState(false);
   const searchParams = useSearchParams();
   const token = searchParams.get('token');
+  const serviceName = searchParams.get('service_name');
 
   const handleSubmit = async (data: SignInFormType) => {
     setIsPending(true);
@@ -75,7 +77,12 @@ const OAuthAuthorizeForm = () => {
 
   return (
     <div className="max-w-180 flex w-full flex-col items-center gap-6">
-      <SharedSignInForm onSubmit={handleSubmit} isPending={isPending} signupHref="/signup" />
+      <SharedSignInForm
+        onSubmit={handleSubmit}
+        isPending={isPending}
+        signupHref="/signup"
+        serviceName={serviceName || undefined}
+      />
     </div>
   );
 };

--- a/packages/shared/src/ui/SignInForm/index.tsx
+++ b/packages/shared/src/ui/SignInForm/index.tsx
@@ -55,8 +55,14 @@ const SignInForm = ({ onSubmit, isPending = false, signupHref, serviceName }: Si
         <div>
           <CardTitle className={cn('text-3xl')}>로그인</CardTitle>
           <CardDescription className={cn('mt-2')}>
-            Data GSM 계정으로{' '}
-            {serviceName ? <strong className={cn('text-primary')}>{serviceName}</strong> : ''}에
+            DataGSM 계정으로{' '}
+            {serviceName ? (
+              <>
+                <strong className={cn('text-primary')}>{serviceName}</strong>에{' '}
+              </>
+            ) : (
+              ''
+            )}
             로그인하세요
           </CardDescription>
         </div>

--- a/packages/shared/src/ui/SignInForm/index.tsx
+++ b/packages/shared/src/ui/SignInForm/index.tsx
@@ -26,9 +26,10 @@ interface SignInFormProps {
   onSubmit: (data: SignInFormType) => void;
   isPending?: boolean;
   signupHref?: string;
+  serviceName?: string;
 }
 
-const SignInForm = ({ onSubmit, isPending = false, signupHref }: SignInFormProps) => {
+const SignInForm = ({ onSubmit, isPending = false, signupHref, serviceName }: SignInFormProps) => {
   const [showPassword, setShowPassword] = useState(false);
 
   const {
@@ -53,7 +54,11 @@ const SignInForm = ({ onSubmit, isPending = false, signupHref }: SignInFormProps
         </div>
         <div>
           <CardTitle className={cn('text-3xl')}>로그인</CardTitle>
-          <CardDescription className={cn('mt-2')}>Data GSM 계정으로 로그인하세요</CardDescription>
+          <CardDescription className={cn('mt-2')}>
+            Data GSM 계정으로{' '}
+            {serviceName ? <strong className={cn('text-primary')}>{serviceName}</strong> : ''}에
+            로그인하세요
+          </CardDescription>
         </div>
       </CardHeader>
 


### PR DESCRIPTION
## 개요 💡

OAuth 클라이언트 API 스펙에 맞춰 `name` 필드를 `clientName`, `serviceName`으로 분리하고 관련 UI를 업데이트합니다.

## 작업내용 ⌨️

- `Client` 타입 및 관련 Request/Response 인터페이스의 `name` → `clientName` + `serviceName` 분리
- `ClientFormSchema` Zod 스키마에 `serviceName` 필드 추가
- `ClientFormDialog`: 폼에 서비스 명칭 입력 필드 추가, submit 데이터 구조 수정
- `ClientSuccessDialog`: 생성 완료 화면에 서비스 명칭 표시
- `ClientList`: 클라이언트 이름과 서비스 명칭을 별도 컬럼으로 분리
- `OAuthAuthorizeForm`: `service_name` 쿼리 파라미터를 읽어 `SignInForm`에 전달
- `SignInForm` (shared): `serviceName` prop 추가, 로그인 페이지에 서비스 명칭 강조 표시

## 스크린샷/동영상 📸

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/b486b50a-483a-43a6-899e-b3f894d24352" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/2e3ae558-11d1-44a0-b26d-a783565cc568" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/1a6e615e-86b6-47e6-bfe7-82cff361d0ff" />
