### PR TITLE
[feat] api key 즉시 갱신

### DIFF
--- a/apps/client/src/widgets/home/index.ts
+++ b/apps/client/src/widgets/home/index.ts
@@ -6,3 +6,4 @@ export * from './model/useDeleteApiKey';
 export * from './model/useGetApiKey';
 export * from './model/useUpdateApiKey';
 export * from './model/useGetAvailableScope';
+export * from './model/useRotateApiKey';

--- a/apps/client/src/widgets/home/model/useRotateApiKey.ts
+++ b/apps/client/src/widgets/home/model/useRotateApiKey.ts
@@ -1,0 +1,17 @@
+import { authQueryKeys, authUrl, post } from '@repo/shared/api';
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { ApiKeyFormType, ApiKeyResponse } from '@/entities/home';
+
+export const useRotateApiKey = (
+  options?: Omit<
+    UseMutationOptions<ApiKeyResponse, AxiosError, ApiKeyFormType>,
+    'mutationKey' | 'mutationFn'
+  >,
+) =>
+  useMutation({
+    mutationKey: authQueryKeys.postRotateApiKey(),
+    mutationFn: (data: ApiKeyFormType) => post<ApiKeyResponse>(authUrl.postRotateApiKey(), data),
+    ...options,
+  });

--- a/apps/client/src/widgets/home/ui/ApiKeyForm/index.tsx
+++ b/apps/client/src/widgets/home/ui/ApiKeyForm/index.tsx
@@ -22,6 +22,7 @@ import {
   useCreateApiKey,
   useGetApiKey,
   useGetAvailableScope,
+  useRotateApiKey,
   useUpdateApiKey,
 } from '@/widgets/home';
 
@@ -64,6 +65,17 @@ const ApiKeyForm = ({ initialApiKeyData, initialAvailableScope, userRole }: ApiK
     },
   });
 
+  const { isPending: isRotatingApiKey, mutate: rotateApiKey } = useRotateApiKey({
+    onSuccess: (data) => {
+      // 마스킹되지 않은 갱신된 키를 캐시에 즉시 설정
+      queryClient.setQueryData(authQueryKeys.getApiKey(), data);
+      toast.success('API Key가 갱신되었습니다.');
+    },
+    onError: () => {
+      toast.error('API Key 갱신에 실패했습니다. 다시 시도해주세요.');
+    },
+  });
+
   const {
     handleSubmit,
     watch,
@@ -90,7 +102,7 @@ const ApiKeyForm = ({ initialApiKeyData, initialAvailableScope, userRole }: ApiK
 
   const buttonText = isCreatingApiKey
     ? 'API 키 생성 중...'
-    : isUpdatingApiKey
+    : isUpdatingApiKey || isRotatingApiKey
       ? 'API 키 갱신 중...'
       : apiKeyData?.data?.apiKey
         ? 'API 키 갱신하기'
@@ -103,14 +115,25 @@ const ApiKeyForm = ({ initialApiKeyData, initialAvailableScope, userRole }: ApiK
     fieldName: 'scopes',
   });
 
-  const onSubmit = ({ scopes, description }: ApiKeyFormType) => {
-    const data = { scopes, description };
+  const onSubmit = (data: ApiKeyFormType) => {
+    const { scopes, description } = data;
 
-    if (apiKeyData?.data?.apiKey) {
-      updateApiKey(data);
-    } else {
+    if (!apiKeyData?.data?.apiKey) {
       createApiKey(data);
+      return;
     }
+
+    const isScopesSame =
+      apiKeyData.data.scopes.length === scopes.length &&
+      apiKeyData.data.scopes.every((s) => scopes.includes(s));
+    const isDescriptionSame = apiKeyData.data.description === description;
+
+    if (isScopesSame && isDescriptionSame) {
+      rotateApiKey(data);
+      return;
+    }
+
+    updateApiKey(data);
   };
 
   if (isLoadingApiKey || isLoadingKeyScope) {
@@ -174,7 +197,11 @@ const ApiKeyForm = ({ initialApiKeyData, initialAvailableScope, userRole }: ApiK
           />
           <Input placeholder="설명을 작성해주세요." {...register('description')} />
           <FormErrorMessage error={errors.description} />
-          <Button disabled={isCreatingApiKey || isUpdatingApiKey} size="lg" type="submit">
+          <Button
+            disabled={isCreatingApiKey || isUpdatingApiKey || isRotatingApiKey}
+            size="lg"
+            type="submit"
+          >
             {buttonText}
           </Button>
         </div>

--- a/apps/client/src/widgets/home/ui/ApiKeyForm/index.tsx
+++ b/apps/client/src/widgets/home/ui/ApiKeyForm/index.tsx
@@ -5,7 +5,16 @@ import { useEffect } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { authQueryKeys } from '@repo/shared/api';
 import { UserRoleType } from '@repo/shared/types';
-import { Button, Card, Checkbox, FormErrorMessage, Input } from '@repo/shared/ui';
+import {
+  Button,
+  Card,
+  Checkbox,
+  FormErrorMessage,
+  Input,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@repo/shared/ui';
 import { cn } from '@repo/shared/utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
@@ -56,9 +65,8 @@ const ApiKeyForm = ({ initialApiKeyData, initialAvailableScope, userRole }: ApiK
 
   const { isPending: isUpdatingApiKey, mutate: updateApiKey } = useUpdateApiKey({
     onSuccess: (data) => {
-      // 마스킹되지 않은 갱신된 키를 캐시에 즉시 설정
+      // 기본 성공 처리 (필요시)
       queryClient.setQueryData(authQueryKeys.getApiKey(), data);
-      toast.success('API Key가 갱신되었습니다.');
     },
     onError: () => {
       toast.error('API Key 갱신에 실패했습니다. 다시 시도해주세요.');
@@ -67,9 +75,8 @@ const ApiKeyForm = ({ initialApiKeyData, initialAvailableScope, userRole }: ApiK
 
   const { isPending: isRotatingApiKey, mutate: rotateApiKey } = useRotateApiKey({
     onSuccess: (data) => {
-      // 마스킹되지 않은 갱신된 키를 캐시에 즉시 설정
+      // 기본 성공 처리 (필요시)
       queryClient.setQueryData(authQueryKeys.getApiKey(), data);
-      toast.success('API Key가 갱신되었습니다.');
     },
     onError: () => {
       toast.error('API Key 갱신에 실패했습니다. 다시 시도해주세요.');
@@ -91,6 +98,18 @@ const ApiKeyForm = ({ initialApiKeyData, initialAvailableScope, userRole }: ApiK
     },
   });
 
+  const watchedScopes = watch('scopes');
+  const watchedDescription = watch('description');
+
+  const isScopesEqual =
+    apiKeyData?.data?.scopes &&
+    apiKeyData.data.scopes.length === watchedScopes.length &&
+    apiKeyData.data.scopes.every((s) => watchedScopes.includes(s));
+
+  const isDescriptionEqual = apiKeyData?.data?.description === watchedDescription;
+
+  const isApiKeyDataEqual = !!apiKeyData?.data?.apiKey && isScopesEqual && isDescriptionEqual;
+
   useEffect(() => {
     if (apiKeyData?.data) {
       reset({
@@ -108,6 +127,12 @@ const ApiKeyForm = ({ initialApiKeyData, initialAvailableScope, userRole }: ApiK
         ? 'API 키 갱신하기'
         : 'API 키 생성하기';
 
+  const buttonTooptipText = !apiKeyData?.data?.apiKey
+    ? '새로운 API 키를 발급합니다.'
+    : isApiKeyDataEqual
+      ? '기존 API 키를 폐기하고 권한 범위와 설명이 같은 새로운 키를 발급합니다.'
+      : 'API 키의 권한 범위 및 설명을 수정한 새로운 키를 발급합니다.';
+
   const { handleScopeToggle, isScopeChecked, getIndentation } = useScopeSelection({
     availableScopes: availableKeyScope,
     watch,
@@ -116,24 +141,27 @@ const ApiKeyForm = ({ initialApiKeyData, initialAvailableScope, userRole }: ApiK
   });
 
   const onSubmit = (data: ApiKeyFormType) => {
-    const { scopes, description } = data;
-
     if (!apiKeyData?.data?.apiKey) {
       createApiKey(data);
       return;
     }
 
-    const isScopesSame =
-      apiKeyData.data.scopes.length === scopes.length &&
-      apiKeyData.data.scopes.every((s) => scopes.includes(s));
-    const isDescriptionSame = apiKeyData.data.description === description;
-
-    if (isScopesSame && isDescriptionSame) {
-      rotateApiKey(data);
+    if (isApiKeyDataEqual) {
+      rotateApiKey(data, {
+        onSuccess: (res) => {
+          queryClient.setQueryData(authQueryKeys.getApiKey(), res);
+          toast.success('갱신에 성공하였습니다.');
+        },
+      });
       return;
     }
 
-    updateApiKey(data);
+    updateApiKey(data, {
+      onSuccess: (res) => {
+        queryClient.setQueryData(authQueryKeys.getApiKey(), res);
+        toast.success('갱신에 성공하였습니다.');
+      },
+    });
   };
 
   if (isLoadingApiKey || isLoadingKeyScope) {
@@ -197,13 +225,47 @@ const ApiKeyForm = ({ initialApiKeyData, initialAvailableScope, userRole }: ApiK
           />
           <Input placeholder="설명을 작성해주세요." {...register('description')} />
           <FormErrorMessage error={errors.description} />
-          <Button
-            disabled={isCreatingApiKey || isUpdatingApiKey || isRotatingApiKey}
-            size="lg"
-            type="submit"
-          >
-            {buttonText}
-          </Button>
+          <div className={cn('flex flex-col gap-2')}>
+            <Tooltip className="w-full">
+              <TooltipTrigger asChild>
+                <Button
+                  className="w-full"
+                  disabled={isCreatingApiKey || isUpdatingApiKey || isRotatingApiKey}
+                  size="lg"
+                  type="submit"
+                >
+                  {buttonText}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{buttonTooptipText}</TooltipContent>
+            </Tooltip>
+          </div>
+          {isApiKeyDataEqual && (
+            <div className={cn('flex flex-col gap-2')}>
+              <Tooltip className="w-full">
+                <TooltipTrigger asChild>
+                  <Button
+                    className="w-full"
+                    disabled={isCreatingApiKey || isUpdatingApiKey || isRotatingApiKey}
+                    size="lg"
+                    type="button"
+                    variant="outline"
+                    onClick={handleSubmit((data) =>
+                      updateApiKey(data, {
+                        onSuccess: (res) => {
+                          queryClient.setQueryData(authQueryKeys.getApiKey(), res);
+                          toast.success('연장에 성공하였습니다.');
+                        },
+                      }),
+                    )}
+                  >
+                    기한 연장하기
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>API 키의 만료 기한을 연장합니다.</TooltipContent>
+              </Tooltip>
+            </div>
+          )}
         </div>
       </form>
     </Card>

--- a/packages/shared/src/api/apiUrls.ts
+++ b/packages/shared/src/api/apiUrls.ts
@@ -34,6 +34,7 @@ export const authUrl = {
   getApiKey: () => '/v1/auth/api-keys/my',
   putApiKey: () => '/v1/auth/api-keys/my',
   postApiKey: () => '/v1/auth/api-keys/my',
+  postRotateApiKey: () => '/v1/auth/api-keys/my/rotations',
   deleteApiKey: () => '/v1/auth/api-keys/my',
   getApiKeys: (page?: number, size?: number, accountEmail?: string) => {
     const params = new URLSearchParams();

--- a/packages/shared/src/api/queryKeys.ts
+++ b/packages/shared/src/api/queryKeys.ts
@@ -22,7 +22,7 @@ export const authQueryKeys = {
   getApiKey: () => ['auth', 'api-keys', 'my', 'get'] as const,
   putApiKey: () => ['auth', 'api-keys', 'my', 'update'] as const,
   postApiKey: () => ['auth', 'api-keys', 'my', 'create'] as const,
-  postRotateApiKey: () => ['auth', 'api-keys', 'my', 'rtate'] as const,
+  postRotateApiKey: () => ['auth', 'api-keys', 'my', 'rotate'] as const,
   deleteApiKey: () => ['auth', 'api-keys', 'my', 'delete'] as const,
   getApiKeys: (page?: number, size?: number, accountEmail?: string) =>
     ['auth', 'api-keys', 'list', { page, size, accountEmail }] as const,

--- a/packages/shared/src/api/queryKeys.ts
+++ b/packages/shared/src/api/queryKeys.ts
@@ -22,6 +22,7 @@ export const authQueryKeys = {
   getApiKey: () => ['auth', 'api-keys', 'my', 'get'] as const,
   putApiKey: () => ['auth', 'api-keys', 'my', 'update'] as const,
   postApiKey: () => ['auth', 'api-keys', 'my', 'create'] as const,
+  postRotateApiKey: () => ['auth', 'api-keys', 'my', 'rtate'] as const,
   deleteApiKey: () => ['auth', 'api-keys', 'my', 'delete'] as const,
   getApiKeys: (page?: number, size?: number, accountEmail?: string) =>
     ['auth', 'api-keys', 'list', { page, size, accountEmail }] as const,


### PR DESCRIPTION
## 개요 💡

api key 즉시 재설정 기능을 추가했습니다.

## 작업내용 ⌨️

scope와 description이 바뀌지 않았을 경우에 rotate를 사용해 재설정하도록 했습니다.

## 스크린샷/동영상 📸

https://github.com/user-attachments/assets/8bac842e-a494-4783-9331-d9c5c4e3d129

## 리뷰 요청사항 👀

특별히 scope와 description이 변경되지 않은 경우가 구상되지 않아 UI를 새로 설계하지 않고, API Key를 업데이트할 때와 동일한 UI로 구성했습니다.
좋은 아이디어가 있으면 공유 부탁드립니다.