### PR TITLE
[feat] NODE_ENV 기반 docs URL 상수 추가

### DIFF
--- a/apps/client/src/app/not-found.tsx
+++ b/apps/client/src/app/not-found.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { DOCS_URL } from '@repo/shared/constants';
 import { Button } from '@repo/shared/ui';
 import { cn } from '@repo/shared/utils';
 
@@ -22,8 +23,7 @@ const NotFound = () => {
             <Link href="/">메인으로 돌아가기</Link>
           </Button>
           <Button asChild variant="outline">
-            <Link href="/docs">기술 문서 보기</Link>
-            {/* TODO: docs 애플리케이션 배포 후 링크 수정 */}
+            <Link href={DOCS_URL}>기술 문서 보기</Link>
           </Button>
         </div>
       </div>

--- a/packages/shared/src/constants/navigation.ts
+++ b/packages/shared/src/constants/navigation.ts
@@ -1,8 +1,13 @@
+export const DOCS_URL =
+  process.env.NODE_ENV === 'production'
+    ? 'https://docs.datagsm-front-client.vercel.app'
+    : 'http://localhost:3002';
+
 export const NAV_LINKS = {
   client: [
     { href: '/', label: '메인' },
     { href: '/clients', label: '클라이언트' },
-    { href: '/docs', label: '독스' }, // TODO: docs 애플리케이션 배포 후 링크 수정
+    { href: DOCS_URL, label: '독스' },
   ],
   admin: [
     { href: '/students', label: '학생' },

--- a/packages/shared/src/constants/navigation.ts
+++ b/packages/shared/src/constants/navigation.ts
@@ -1,7 +1,4 @@
-export const DOCS_URL =
-  process.env.NODE_ENV === 'production'
-    ? 'https://docs.datagsm-front-client.vercel.app'
-    : 'http://localhost:3002';
+export const DOCS_URL = process.env.NEXT_PUBLIC_DOCS_URL ?? 'http://localhost:3002';
 
 export const NAV_LINKS = {
   client: [


### PR DESCRIPTION
## 개요 💡

`NODE_ENV`에 따라 docs URL을 분기 처리합니다. 기존에는 `/docs` 경로로 하드코딩되어 있었으나, 배포 환경과 개발 환경에서 실제 docs 서비스 URL이 다르기 때문에 환경변수 기반으로 동적으로 설정되도록 개선합니다.

## 작업내용 ⌨️

- navigation.ts에 `DOCS_URL` 상수 추가
  - `production`: `https://docs.datagsm-front-client.vercel.app`
  - 그 외: `http://localhost:3002`
- `NAV_LINKS`의 독스 href를 `DOCS_URL`로 교체
- not-found.tsx의 독스 링크를 `DOCS_URL`로 교체