### PR TITLE
[fix] OAuth 예제 경로 오타 수정

### DIFF
--- a/apps/docs/src/widgets/docs/model/constants.ts
+++ b/apps/docs/src/widgets/docs/model/constants.ts
@@ -102,7 +102,7 @@ export const docsSections: DocsSection[] = [
         children: [
           {
             label: 'React + Spring Boot (BFF)',
-            href: '/oauth/examples/react-spring-boot-boot',
+            href: '/oauth/examples/react-spring-boot',
           },
           {
             label: 'Next.js + Spring Boot',


### PR DESCRIPTION
## 개요 💡
OAuth 가이드 내 잘못된 링크 주소를 수정했습니다.

## 작업내용 ⌨️
- constants.ts에서 OAuth 예제의 오타(`react-spring-boot-boot` -> `react-spring-boot`)를 수정했습니다.

## 관련 이슈 🚨
https://github.com/themoment-team/datagsm-front/issues/78