### PR TITLE
[fix] docs 경로 수정

### DIFF
--- a/apps/docs/src/widgets/docs/model/constants.ts
+++ b/apps/docs/src/widgets/docs/model/constants.ts
@@ -102,7 +102,7 @@ export const docsSections: DocsSection[] = [
         children: [
           {
             label: 'React + Spring Boot (BFF)',
-            href: '/oauth/examples/react-spring-boot-boot',
+            href: '/oauth/examples/react-spring-boot',
           },
           {
             label: 'Next.js + Spring Boot',


### PR DESCRIPTION
## 개요 💡

docs에서 잘못된 경로를 수정했습니다.

## 작업내용 ⌨️

AOuth의 Examples중 하나인 `React + Spring Boot`의 경로가  `/react-spring-boot-boot`로 잘못 설정되어 있었습니다.

## 관련 이슈 🚨

#78 