### PR TITLE
[feat] 사이드바 내부 세로 스크롤 적용

### DIFF
--- a/apps/docs/src/widgets/docs/ui/DocsSidebar/index.tsx
+++ b/apps/docs/src/widgets/docs/ui/DocsSidebar/index.tsx
@@ -21,7 +21,7 @@ const DocsSidebar = () => {
         </button>
       </div>
 
-      <aside className="sticky top-24 hidden h-fit w-64 shrink-0 lg:block">
+      <aside className="[&::-webkit-scrollbar-thumb]:bg-border sticky top-24 hidden max-h-[calc(100vh-7rem)] w-64 shrink-0 overflow-y-auto lg:block [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar]:w-1">
         <h2 className="text-muted-foreground mb-4 text-sm font-semibold">목차</h2>
         <SidebarContent />
       </aside>
@@ -32,18 +32,18 @@ const DocsSidebar = () => {
             className="fixed inset-0 z-40 bg-black/50 lg:hidden"
             onClick={() => setMobileMenuOpen(false)}
           />
-          <aside className="bg-background fixed left-0 top-0 z-50 h-full w-64 shadow-xl lg:hidden">
-            <div className="p-4">
-              <div className="mb-6 flex items-center justify-between">
-                <h2 className="text-sm font-semibold">목차</h2>
-                <button
-                  onClick={() => setMobileMenuOpen(false)}
-                  className="hover:bg-muted rounded-md p-1"
-                >
-                  <X className="h-4 w-4" />
-                </button>
-              </div>
+          <aside className="bg-background fixed left-0 top-0 z-50 flex h-full w-64 flex-col shadow-xl lg:hidden">
+            <div className="flex shrink-0 items-center justify-between p-4 pb-0">
+              <h2 className="text-sm font-semibold">목차</h2>
+              <button
+                onClick={() => setMobileMenuOpen(false)}
+                className="hover:bg-muted rounded-md p-1"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
 
+            <div className="[&::-webkit-scrollbar-thumb]:bg-border flex-1 overflow-y-auto p-4 pt-4 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar]:w-1">
               <SidebarContent onLinkClick={() => setMobileMenuOpen(false)} />
             </div>
           </aside>

--- a/apps/docs/src/widgets/docs/ui/DocsSidebar/index.tsx
+++ b/apps/docs/src/widgets/docs/ui/DocsSidebar/index.tsx
@@ -6,6 +6,9 @@ import { Menu, X } from 'lucide-react';
 
 import { SidebarContent } from './SidebarContent';
 
+const scrollbarStyles =
+  '[&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border';
+
 const DocsSidebar = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
@@ -21,7 +24,9 @@ const DocsSidebar = () => {
         </button>
       </div>
 
-      <aside className="[&::-webkit-scrollbar-thumb]:bg-border sticky top-24 hidden max-h-[calc(100vh-7rem)] w-64 shrink-0 overflow-y-auto lg:block [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar]:w-1">
+      <aside
+        className={`${scrollbarStyles} sticky top-24 hidden max-h-[calc(100vh-7rem)] w-64 shrink-0 overflow-y-auto lg:block`}
+      >
         <h2 className="text-muted-foreground mb-4 text-sm font-semibold">목차</h2>
         <SidebarContent />
       </aside>
@@ -43,7 +48,7 @@ const DocsSidebar = () => {
               </button>
             </div>
 
-            <div className="[&::-webkit-scrollbar-thumb]:bg-border flex-1 overflow-y-auto p-4 pt-4 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar]:w-1">
+            <div className={`${scrollbarStyles} flex-1 overflow-y-auto p-4 pt-4`}>
               <SidebarContent onLinkClick={() => setMobileMenuOpen(false)} />
             </div>
           </aside>


### PR DESCRIPTION
## 개요 💡

docs 사이드바의 콘텐츠가 뷰포트 높이를 초과할 경우 하단 항목이 잘려 보이지 않는 문제를 수정합니다.

## 작업내용 ⌨️

- 데스크톱 사이드바에 `max-h-[calc(100vh-7rem)]` + `overflow-y-auto` 적용하여 내부 세로 스크롤 활성화
- 모바일 드로어의 콘텐츠 영역도 동일하게 스크롤 가능하도록 수정
- `[&::-webkit-scrollbar]:w-1` 등 webkit 스크롤바 커스터마이징으로 스크롤바 두께 축소 및 스타일 개선

## 스크린샷/동영상 📸

https://github.com/user-attachments/assets/afc2b24e-7224-49a0-b33e-0a080436245c

