### PR TITLE
[feat] UI 스푸핑 방지를 위해 서비스명을 API로 조회하도록 변경

### DIFF
--- a/apps/client/next.config.ts
+++ b/apps/client/next.config.ts
@@ -4,8 +4,8 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return [
       {
-        source: '/api/:path*',
-        destination: `${process.env.NEXT_PUBLIC_API_BASE_URL}/:path*`,
+        source: '/api/((?!oauth).+)',
+        destination: `${process.env.NEXT_PUBLIC_API_BASE_URL}/$1`,
       },
     ];
   },

--- a/apps/client/src/app/api/oauth/sessions/[token]/route.ts
+++ b/apps/client/src/app/api/oauth/sessions/[token]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+
+  const oauthBaseUrl = process.env.NEXT_PUBLIC_OAUTH_BASE_URL;
+
+  if (!oauthBaseUrl) {
+    return NextResponse.json(
+      { error: 'server_error', error_description: 'OAuth 서버 URL이 설정되지 않았습니다.' },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const response = await fetch(`${oauthBaseUrl}/v1/oauth/sessions/${token}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    const data = await response.json();
+
+    return NextResponse.json(data, { status: response.status });
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.';
+    return NextResponse.json(
+      { error: 'server_error', error_description: errorMessage },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/client/src/app/api/oauth/sessions/[token]/route.ts
+++ b/apps/client/src/app/api/oauth/sessions/[token]/route.ts
@@ -16,15 +16,19 @@ export async function GET(
   }
 
   try {
-    const response = await fetch(`${oauthBaseUrl}/v1/oauth/sessions/${token}`, {
+    const response = await fetch(`${oauthBaseUrl}/v1/oauth/sessions/${encodeURIComponent(token)}`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
       },
     });
+
     const data = await response.json();
 
-    return NextResponse.json(data, { status: response.status });
+    return NextResponse.json(
+      { data: { service_name: data?.data?.service_name } },
+      { status: response.status },
+    );
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.';
     return NextResponse.json(

--- a/apps/client/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
+++ b/apps/client/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useSearchParams } from 'next/navigation';
 
@@ -9,10 +9,25 @@ import { SignInForm as SharedSignInForm } from '@repo/shared/ui';
 import { toast } from 'sonner';
 
 const OAuthAuthorizeForm = () => {
+  const [serviceName, setServiceName] = useState<string | undefined>();
   const [isPending, setIsPending] = useState(false);
   const searchParams = useSearchParams();
   const token = searchParams.get('token');
-  const serviceName = searchParams.get('service_name');
+
+  useEffect(() => {
+    if (!token) return;
+    console.log('Fetching service name for token:', token);
+
+    fetch(`/api/oauth/sessions/${token}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data?.data?.service_name) {
+          setServiceName(data.data.service_name);
+          console.log('서비스 이름:', data.data.service_name);
+        }
+      })
+      .catch(() => {});
+  }, [token]);
 
   const handleSubmit = async (data: SignInFormType) => {
     setIsPending(true);

--- a/apps/client/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
+++ b/apps/client/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
@@ -24,7 +24,9 @@ const OAuthAuthorizeForm = () => {
           setServiceName(data.data.service_name);
         }
       })
-      .catch(() => {});
+      .catch((error) => {
+        console.error('서비스 이름 조회 실패:', error);
+      });
   }, [token]);
 
   const handleSubmit = async (data: SignInFormType) => {

--- a/apps/client/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
+++ b/apps/client/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
@@ -16,14 +16,12 @@ const OAuthAuthorizeForm = () => {
 
   useEffect(() => {
     if (!token) return;
-    console.log('Fetching service name for token:', token);
 
     fetch(`/api/oauth/sessions/${token}`)
       .then((res) => res.json())
       .then((data) => {
         if (data?.data?.service_name) {
           setServiceName(data.data.service_name);
-          console.log('서비스 이름:', data.data.service_name);
         }
       })
       .catch(() => {});


### PR DESCRIPTION
## 개요 💡
> 기존에는 URL 파라미터(`service_name`)로 서비스명을 전달받아 로그인 폼에 표시했습니다.
이 방식은 사용자가 URL을 직접 조작해 서비스명을 변경할 수 있어 URL 파라미터 변조에 취약했습니다.
이를 방지하기 위해 토큰 기반으로 서버에서 서비스명을 조회하도록 변경했습니다.

## 작업내용 ⌨️
- URL 파라미터 `service_name` 제거
- `GET /v1/oauth/sessions/{token}` API 프록시 라우트 추가 (`app/api/oauth/sessions/[token]/route.ts`)
- `OAuthAuthorizeForm`에서 토큰으로 서비스명을 조회하도록 수정
- `/api/oauth` 경로가 웹 서버로 잘못 프록시되던 `next.config.ts` rewrite 버그 수정

## 스크린샷/동영상 📸
<img width="1669" height="926" alt="image" src="https://github.com/user-attachments/assets/e3840305-2fda-4b21-a5ae-1e623c88b814" />

## 관련 이슈 🚨
> 기존 `next.config.ts`의 rewrite 설정(`/api/:path*`)이 `/api/oauth/*` 요청을
OAuth 서버가 아닌 웹 서버로 잘못 프록시하고 있었습니다.
`/api/((?!oauth).+)` 정규식으로 변경해 oauth 경로를 rewrite 대상에서 제외했습니다.
> ⚠️ 해당 수정은 임시 해결책으로, oauth 모듈 분리 작업 시 근본적으로 해결 예정입니다.

## 리뷰 요청사항 👀
- 로그인 페이지 진입 시 서비스명이 정상 표시되는지 확인 ✅
- URL에서 service_name 파라미터 조작 시 서비스명이 변경되지 않는지 확인 ✅