### PR TITLE
docs: llms.txt 추가

### DIFF
--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,0 +1,28 @@
+# DataGSM Docs
+
+> 광주소프트웨어마이스터고등학교(GSM)의 학생·동아리·프로젝트·급식·학사일정 데이터를 중앙집중적으로 제공하는 OpenAPI 및 OAuth 인증 서비스의 공식 기술 문서입니다. 더모먼트팀이 2025년부터 운영하며, GAuth 종료 이후 OAuth 인증 시스템도 함께 제공합니다.
+
+## Docs
+
+- [Overview](https://datagsm-front-client.vercel.app/): 서비스 소개, 역사, 제공 기능, 빠른 시작 가이드
+- [OpenAPI 개요](https://datagsm-front-client.vercel.app/api): API 키 발급, 권한 범위, 공통 헤더, 상태 코드, API 키 관리 권장 사항
+- [학생 데이터 API](https://datagsm-front-client.vercel.app/api/http/student): GET /v1/students — 학년·반·번호·성별·역할·기숙사 호실 등 필터링, 페이지네이션, 정렬 지원. STUDENT_READ 권한 필요
+- [동아리 데이터 API](https://datagsm-front-client.vercel.app/api/http/club): GET /v1/clubs — 동아리 종류(전공·취업·자율) 필터링, 부장·부원 데이터 포함. CLUB_READ 권한 필요
+- [프로젝트 데이터 API](https://datagsm-front-client.vercel.app/api/http/project): GET /v1/projects — 동아리별 프로젝트 및 참가자 데이터 조회. PROJECT_READ 권한 필요
+- [NEIS 데이터 API 개요](https://datagsm-front-client.vercel.app/api/http/neis): 급식·학사일정 API 공통 사항. NEIS_READ 권한 필요
+- [급식 데이터 API](https://datagsm-front-client.vercel.app/api/http/neis/meals): GET /v1/neis/meals — 날짜·기간 기준 급식 메뉴, 알레르기, 영양 데이터 조회
+- [학사일정 데이터 API](https://datagsm-front-client.vercel.app/api/http/neis/schedules): GET /v1/neis/schedules — 날짜·기간 기준 학사일정·행사 데이터 조회
+- [SDK 개요](https://datagsm-front-client.vercel.app/api/sdk): OpenAPI SDK 사용 이점 — 타입 안전성, 에러 처리, 보일러플레이트 제거 비교
+- [SDK Java/Kotlin](https://datagsm-front-client.vercel.app/api/sdk/java): datagsm-openapi-sdk-java:1.1.1 (JitPack, OkHttp 기반). JDK 13+
+- [SDK JavaScript/TypeScript](https://datagsm-front-client.vercel.app/api/sdk/javascript): datagsm-openapi-sdk-javascript (npm, fetch 기반). Node.js 20+
+- [SDK Python](https://datagsm-front-client.vercel.app/api/sdk/python): datagsm-openapi-sdk (pip, httpx + Pydantic v2 기반). Python 3.9+
+- [OAuth 개요](https://datagsm-front-client.vercel.app/oauth): OAuth 2.0 Authorization Code Grant 개요, PKCE 도입 배경, 토큰 유효기간, 인증 플로우 다이어그램
+- [인증 흐름 시작](https://datagsm-front-client.vercel.app/oauth/http/authorize): GET /v1/oauth/authorize — client_id, redirect_uri, state, code_challenge(PKCE) 파라미터
+- [토큰 교환](https://datagsm-front-client.vercel.app/oauth/http/token-exchange): POST /v1/oauth/token (grant_type=authorization_code) — PKCE(code_verifier) 및 client_secret 방식 모두 지원
+- [토큰 갱신](https://datagsm-front-client.vercel.app/oauth/http/token-refresh): POST /v1/oauth/token (grant_type=refresh_token) — Refresh Token으로 Access Token 갱신
+- [사용자 데이터 조회](https://datagsm-front-client.vercel.app/oauth/http/userinfo): GET /userinfo — Bearer Token으로 사용자 기본 정보 및 학생 상세 정보 조회
+- [PKCE 가이드](https://datagsm-front-client.vercel.app/oauth/pkce): RFC 7636 상세 설명, code_verifier/code_challenge 생성 방법, client_secret 방식과 비교
+- [OAuth 구현 예제](https://datagsm-front-client.vercel.app/oauth/examples): React+Spring Boot BFF(PKCE), Next.js+Spring Boot(PKCE), React+Spring Boot Kotlin(레거시), Vanilla JS+NestJS(레거시)
+- [OAuth SDK 개요](https://datagsm-front-client.vercel.app/oauth/sdk): OAuth SDK 사용 이점 비교
+- [OAuth SDK Java](https://datagsm-front-client.vercel.app/oauth/sdk/java): Java/Kotlin 환경용 OAuth 클라이언트 SDK
+- [OAuth SDK React](https://datagsm-front-client.vercel.app/oauth/sdk/react): React 환경용 OAuth 클라이언트 SDK


### PR DESCRIPTION
## 개요 💡

LLM이 DataGSM 문서 구조를 빠르게 파악할 수 있도록 `llms.txt`를 추가했습니다.

## 작업내용 ⌨️

- `apps/docs/public/llms.txt` 추가
  - 서비스 개요, OpenAPI(학생·동아리·프로젝트·NEIS), SDK(Java/JS/Python), OAuth HTTP 엔드포인트, PKCE 가이드, 구현 예제 등 문서 전체 링크 포함