### PR TITLE
[update] 로그인 시 이메일 도메인 기본값 추가

### DIFF
--- a/packages/shared/src/types/auth.ts
+++ b/packages/shared/src/types/auth.ts
@@ -19,13 +19,7 @@ interface SignInResponseData {
 export type SignInResponse = ApiResponse<SignInResponseData>;
 
 export const SignInFormSchema = z.object({
-  email: z
-    .string()
-    .min(1, { message: '이메일을 입력해주세요.' })
-    .pipe(z.email({ message: '올바른 이메일 형식이 아닙니다.' }))
-    .refine((email) => email.endsWith('@gsm.hs.kr'), {
-      message: '@gsm.hs.kr 도메인 계정만 사용 가능합니다.',
-    }),
+  email: z.string().min(1, { message: '이메일을 입력해주세요.' }),
   password: z
     .string()
     .min(1, { message: '비밀번호를 입력해주세요.' })

--- a/packages/shared/src/ui/SignInForm/index.tsx
+++ b/packages/shared/src/ui/SignInForm/index.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { SignInFormType } from '@repo/shared/types';
+import { SignInFormSchema, SignInFormType } from '@repo/shared/types';
 import {
   Button,
   Card,
@@ -23,18 +23,7 @@ import { Database, Eye, EyeOff } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-const signInLocalFormSchema = z.object({
-  emailLocal: z.string().min(1, { message: '이메일을 입력해주세요.' }),
-  password: z
-    .string()
-    .min(1, { message: '비밀번호를 입력해주세요.' })
-    .min(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
-    .regex(/^(?=.*[a-zA-Z])(?=.*[0-9])/, {
-      message: '비밀번호는 영문과 숫자를 포함해야 합니다.',
-    }),
-});
-
-type SignInLocalFormType = z.infer<typeof signInLocalFormSchema>;
+type SignInLocalFormType = z.infer<typeof SignInFormSchema>;
 
 interface SignInFormProps {
   onSubmit: (data: SignInFormType) => void;
@@ -51,11 +40,11 @@ const SignInForm = ({ onSubmit, isPending = false, signupHref, serviceName }: Si
     handleSubmit,
     formState: { errors },
   } = useForm<SignInLocalFormType>({
-    resolver: zodResolver(signInLocalFormSchema),
+    resolver: zodResolver(SignInFormSchema),
   });
 
   const handleFormSubmit = handleSubmit((data) =>
-    onSubmit({ email: `${data.emailLocal}@gsm.hs.kr`, password: data.password }),
+    onSubmit({ email: `${data.email}@gsm.hs.kr`, password: data.password }),
   );
 
   return (
@@ -93,19 +82,19 @@ const SignInForm = ({ onSubmit, isPending = false, signupHref, serviceName }: Si
                 id="emailLocal"
                 type="text"
                 placeholder="이메일을 입력하세요"
-                {...register('emailLocal')}
+                {...register('email')}
                 disabled={isPending}
                 className={cn('rounded-r-none')}
               />
               <span
                 className={cn(
-                  'border-input bg-muted text-muted-foreground flex h-9 items-center rounded-r-md border border-l-0 px-3 text-sm whitespace-nowrap',
+                  'border-input bg-muted text-muted-foreground flex h-9 items-center whitespace-nowrap rounded-r-md border border-l-0 px-3 text-sm',
                 )}
               >
                 @gsm.hs.kr
               </span>
             </div>
-            <FormErrorMessage error={errors.emailLocal} />
+            <FormErrorMessage error={errors.email} />
           </div>
 
           <div className={cn('space-y-2')}>

--- a/packages/shared/src/ui/SignInForm/index.tsx
+++ b/packages/shared/src/ui/SignInForm/index.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { SignInFormSchema, SignInFormType } from '@repo/shared/types';
+import { SignInFormType } from '@repo/shared/types';
 import {
   Button,
   Card,
@@ -21,6 +21,20 @@ import {
 import { cn } from '@repo/shared/utils';
 import { Database, Eye, EyeOff } from 'lucide-react';
 import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+const signInLocalFormSchema = z.object({
+  emailLocal: z.string().min(1, { message: '이메일을 입력해주세요.' }),
+  password: z
+    .string()
+    .min(1, { message: '비밀번호를 입력해주세요.' })
+    .min(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
+    .regex(/^(?=.*[a-zA-Z])(?=.*[0-9])/, {
+      message: '비밀번호는 영문과 숫자를 포함해야 합니다.',
+    }),
+});
+
+type SignInLocalFormType = z.infer<typeof signInLocalFormSchema>;
 
 interface SignInFormProps {
   onSubmit: (data: SignInFormType) => void;
@@ -36,11 +50,13 @@ const SignInForm = ({ onSubmit, isPending = false, signupHref, serviceName }: Si
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<SignInFormType>({
-    resolver: zodResolver(SignInFormSchema),
+  } = useForm<SignInLocalFormType>({
+    resolver: zodResolver(signInLocalFormSchema),
   });
 
-  const handleFormSubmit = handleSubmit(onSubmit);
+  const handleFormSubmit = handleSubmit((data) =>
+    onSubmit({ email: `${data.emailLocal}@gsm.hs.kr`, password: data.password }),
+  );
 
   return (
     <Card className={cn('w-full max-w-md')}>
@@ -71,15 +87,25 @@ const SignInForm = ({ onSubmit, isPending = false, signupHref, serviceName }: Si
       <form onSubmit={handleFormSubmit}>
         <CardContent className={cn('space-y-4')}>
           <div className={cn('space-y-2')}>
-            <Label htmlFor="email">이메일</Label>
-            <Input
-              id="email"
-              type="email"
-              placeholder="example@gsm.hs.kr"
-              {...register('email')}
-              disabled={isPending}
-            />
-            <FormErrorMessage error={errors.email} />
+            <Label htmlFor="emailLocal">이메일</Label>
+            <div className={cn('flex items-center')}>
+              <Input
+                id="emailLocal"
+                type="text"
+                placeholder="이메일을 입력하세요"
+                {...register('emailLocal')}
+                disabled={isPending}
+                className={cn('rounded-r-none')}
+              />
+              <span
+                className={cn(
+                  'border-input bg-muted text-muted-foreground flex h-9 items-center rounded-r-md border border-l-0 px-3 text-sm whitespace-nowrap',
+                )}
+              >
+                @gsm.hs.kr
+              </span>
+            </div>
+            <FormErrorMessage error={errors.emailLocal} />
           </div>
 
           <div className={cn('space-y-2')}>

--- a/packages/shared/src/ui/SignInForm/index.tsx
+++ b/packages/shared/src/ui/SignInForm/index.tsx
@@ -23,6 +23,8 @@ import { Database, Eye, EyeOff } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
+const EMAIL_DOMAIN = '@gsm.hs.kr';
+
 type SignInLocalFormType = z.infer<typeof SignInFormSchema>;
 
 interface SignInFormProps {
@@ -44,7 +46,7 @@ const SignInForm = ({ onSubmit, isPending = false, signupHref, serviceName }: Si
   });
 
   const handleFormSubmit = handleSubmit((data) =>
-    onSubmit({ email: `${data.email}@gsm.hs.kr`, password: data.password }),
+    onSubmit({ email: `${data.email}${EMAIL_DOMAIN}`, password: data.password }),
   );
 
   return (
@@ -91,7 +93,7 @@ const SignInForm = ({ onSubmit, isPending = false, signupHref, serviceName }: Si
                   'border-input bg-muted text-muted-foreground flex h-9 items-center whitespace-nowrap rounded-r-md border border-l-0 px-3 text-sm',
                 )}
               >
-                @gsm.hs.kr
+                {EMAIL_DOMAIN}
               </span>
             </div>
             <FormErrorMessage error={errors.email} />


### PR DESCRIPTION
## 개요 💡

로그인 시 `@gsm.hs.kr` 도메인을 무조건 사용합니다. 그러나 해당 값이 기본값으로 들어가 있지 않아 불편하다는 피드백이 있었습니다. 해당 이슈를 수정합니다.

## 작업내용 ⌨️
로그인 시 `@gsm.hs.kr` 도메인을 사용하도록 수정했습니다. 스키마 정의를 추가하고 이를 적용하며 사용자가 `s24058`과 같은 자신의 이메일 고유 식별자만 입력하면 되도록 하였습니다.

## 스크린샷/동영상 📸
<img width="506" height="530" alt="image" src="https://github.com/user-attachments/assets/fa54740c-0c6f-4748-907d-ca8af9022b25" />


https://github.com/user-attachments/assets/5dd6bc0c-2c33-429b-a92d-36866829e81e



