### PR TITLE
[hotfix] api key manager

### DIFF
--- a/apps/client/src/views/home/ui/HomePage/index.tsx
+++ b/apps/client/src/views/home/ui/HomePage/index.tsx
@@ -2,7 +2,7 @@ import { UserRoleType } from '@repo/shared/types';
 import { cn } from '@repo/shared/utils';
 
 import { getApiKey, getAvailableScope } from '@/views/home';
-import { ApiKeyDisplay, ApiKeyFormDialog, ApiKeyHeader } from '@/widgets/home';
+import { ApiKeyHeader, ApiKeyManager } from '@/widgets/home';
 
 const HomePage = async () => {
   const userRole: UserRoleType = 'USER';
@@ -15,16 +15,13 @@ const HomePage = async () => {
   return (
     <div className={cn('bg-background h-[calc(100vh-4.0625rem)]')}>
       <main className={cn('container mx-auto px-4 py-16')}>
-        <div className={cn('mx-auto max-w-2xl')}>
+        <div className={cn('mx-auto max-w-3xl')}>
           <ApiKeyHeader />
-          <div className={cn('flex flex-col items-center gap-6')}>
-            <ApiKeyDisplay initialApiKeyData={initialApiKeyData} />
-            <ApiKeyFormDialog
-              initialApiKeyData={initialApiKeyData}
-              initialAvailableScope={initialAvailableScope}
-              userRole={userRole}
-            />
-          </div>
+          <ApiKeyManager
+            initialApiKeyData={initialApiKeyData}
+            initialAvailableScope={initialAvailableScope}
+            userRole={userRole}
+          />
         </div>
       </main>
     </div>

--- a/apps/client/src/widgets/home/index.ts
+++ b/apps/client/src/widgets/home/index.ts
@@ -1,2 +1,2 @@
-export { ApiKeyHeader, ApiKeyDisplay, ApiKeyForm, ApiKeyFormDialog } from '@repo/shared/ui';
+export { ApiKeyHeader, ApiKeyDisplay, ApiKeyForm, ApiKeyFormDialog, ApiKeyManager } from '@repo/shared/ui';
 export * from '@repo/shared/hooks';

--- a/packages/shared/src/ui/ApiKeyFormDialog/index.tsx
+++ b/packages/shared/src/ui/ApiKeyFormDialog/index.tsx
@@ -14,8 +14,7 @@ import {
 import { cn } from '@repo/shared/utils';
 import { Key } from 'lucide-react';
 
-import ApiKeyDisplay from '../ApiKeyDisplay';
-import ApiKeyForm from '../ApiKeyForm';
+import ApiKeyManager from '../ApiKeyManager';
 
 interface ApiKeyFormDialogProps {
   trigger?: React.ReactNode;
@@ -55,18 +54,18 @@ const ApiKeyFormDialog = ({
             <div className="bg-primary/10 inline-flex h-16 w-16 items-center justify-center rounded-full">
               <Key className="text-primary h-8 w-8" />
             </div>
-            <DialogTitle className="text-3xl font-bold">ADMIN API Key</DialogTitle>
+            <DialogTitle className="text-3xl font-bold">
+              {userRole === 'ADMIN' ? 'ADMIN API Key' : 'API Key Management'}
+            </DialogTitle>
           </div>
         </DialogHeader>
 
-        <div className={cn('flex flex-col gap-6 p-6')}>
-          <ApiKeyForm
-            initialApiKeyData={initialApiKeyData}
-            initialAvailableScope={initialAvailableScope}
-            userRole={userRole}
-          />
-          <ApiKeyDisplay initialApiKeyData={initialApiKeyData} />
-        </div>
+        <ApiKeyManager
+          className="p-6"
+          initialApiKeyData={initialApiKeyData}
+          initialAvailableScope={initialAvailableScope}
+          userRole={userRole}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/packages/shared/src/ui/ApiKeyManager/index.tsx
+++ b/packages/shared/src/ui/ApiKeyManager/index.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { ApiKeyResponse, AvailableScopeListResponse, UserRoleType } from '@repo/shared/types';
+import { cn } from '@repo/shared/utils';
+
+import ApiKeyDisplay from '../ApiKeyDisplay';
+import ApiKeyForm from '../ApiKeyForm';
+
+interface ApiKeyManagerProps {
+  initialApiKeyData?: ApiKeyResponse;
+  initialAvailableScope?: AvailableScopeListResponse;
+  userRole: UserRoleType;
+  className?: string;
+  showDisplay?: boolean;
+}
+
+const ApiKeyManager = ({
+  initialApiKeyData,
+  initialAvailableScope,
+  userRole,
+  className,
+  showDisplay = true,
+}: ApiKeyManagerProps) => {
+  return (
+    <div className={cn('flex flex-col gap-6', className)}>
+      <ApiKeyForm
+        initialApiKeyData={initialApiKeyData}
+        initialAvailableScope={initialAvailableScope}
+        userRole={userRole}
+      />
+      {showDisplay && <ApiKeyDisplay initialApiKeyData={initialApiKeyData} />}
+    </div>
+  );
+};
+
+export default ApiKeyManager;

--- a/packages/shared/src/ui/index.ts
+++ b/packages/shared/src/ui/index.ts
@@ -16,6 +16,7 @@ export { default as ApiKeyForm } from './ApiKeyForm';
 export { default as ApiKeyDisplay } from './ApiKeyDisplay';
 export { default as ApiKeyHeader } from './ApiKeyHeader';
 export { default as ApiKeyFormDialog } from './ApiKeyFormDialog';
+export { default as ApiKeyManager } from './ApiKeyManager';
 export { default as SignInForm } from './SignInForm';
 export { default as Header } from './Header';
 export { default as FormErrorMessage } from './FormErrorMessage';


### PR DESCRIPTION
## 개요 💡

어드민의 api key 발급 ui와 client의 api key 발급 ui가 혼용되어 사용되는걸 해결했습니다.

## 작업내용 ⌨️

api key manager를 추가하여 보다 원활하게 api key를 관리하도록 했습니다

