### PR TITLE
[feat] 로그인 failed 페이지 추가

### DIFF
--- a/apps/client/src/app/oauth/failed/page.tsx
+++ b/apps/client/src/app/oauth/failed/page.tsx
@@ -1,7 +1,7 @@
 import { LoginFailedPage } from '@/views/oauth';
 
-const failed = () => {
+const FailedPage = () => {
   return <LoginFailedPage />;
 };
 
-export default failed;
+export default FailedPage;

--- a/apps/client/src/app/oauth/failed/page.tsx
+++ b/apps/client/src/app/oauth/failed/page.tsx
@@ -1,0 +1,7 @@
+import { LoginFailedPage } from '@/views/oauth';
+
+const failed = () => {
+  return <LoginFailedPage />;
+};
+
+export default failed;

--- a/apps/client/src/views/oauth/index.ts
+++ b/apps/client/src/views/oauth/index.ts
@@ -1,1 +1,2 @@
 export { default as OAuthAuthorizePage } from './ui/OAuthAuthorizePage';
+export { default as LoginFailedPage } from './ui/failedPage';

--- a/apps/client/src/views/oauth/ui/failedPage/index.tsx
+++ b/apps/client/src/views/oauth/ui/failedPage/index.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@repo/shared/ui';
+import { ExternalLink, X } from 'lucide-react';
+
+const LoginFailedPage = () => {
+  return (
+    <div className="bg-background flex min-h-screen items-center justify-center px-4">
+      <Card className="w-full max-w-md text-center">
+        <CardHeader className="space-y-4 pb-4">
+          <div className="mx-auto inline-flex h-20 w-20 items-center justify-center rounded-full bg-red-500/10">
+            <X className="h-10 w-10 text-red-500" />
+          </div>
+          <div className="space-y-2">
+            <CardTitle className="text-2xl">세션이 만료되었습니다</CardTitle>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-6">
+          <div className="bg-muted/50 space-y-2 rounded-lg p-4">
+            <p className="text-muted-foreground text-sm">이 창을 닫고 원래 페이지로 돌아가서</p>
+            <p className="text-base font-medium">다시 로그인을 진행해주세요</p>
+          </div>
+
+          <div className="text-muted-foreground flex items-center justify-center gap-2 text-sm">
+            <ExternalLink className="h-4 w-4" />
+            <span>창을 닫은 후 로그인을 시도했던 서비스로 돌아가세요</span>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default LoginFailedPage;

--- a/apps/client/src/views/oauth/ui/failedPage/index.tsx
+++ b/apps/client/src/views/oauth/ui/failedPage/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Card, CardContent, CardHeader, CardTitle } from '@repo/shared/ui';
 import { ExternalLink, X } from 'lucide-react';
 

--- a/apps/client/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
+++ b/apps/client/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { SignInFormType } from '@repo/shared/types';
 import { SignInForm as SharedSignInForm } from '@repo/shared/ui';
@@ -13,6 +13,8 @@ const OAuthAuthorizeForm = () => {
   const [isPending, setIsPending] = useState(false);
   const searchParams = useSearchParams();
   const token = searchParams.get('token');
+
+  const router = useRouter();
 
   useEffect(() => {
     if (!token) return;
@@ -62,21 +64,16 @@ const OAuthAuthorizeForm = () => {
       }
 
       if (!response.ok) {
-        const errorData = await response.json();
-
-        if (errorData.error_description) {
-          toast.error(errorData.error_description);
-        } else {
-          switch (response.status) {
-            case 400:
-              toast.error('세션이 만료되었습니다. 다시 시도해주세요.');
-              break;
-            case 401:
-              toast.error('이메일 또는 비밀번호가 일치하지 않습니다.');
-              break;
-            default:
-              toast.error('로그인에 실패했습니다.');
-          }
+        switch (response.status) {
+          case 400:
+            console.log('400');
+            router.push('/oauth/failed');
+            break;
+          case 401:
+            toast.error('이메일 또는 비밀번호가 일치하지 않습니다.');
+            break;
+          default:
+            toast.error('로그인에 실패했습니다.');
         }
       }
     } catch (error) {

--- a/apps/client/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
+++ b/apps/client/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
@@ -66,7 +66,6 @@ const OAuthAuthorizeForm = () => {
       if (!response.ok) {
         switch (response.status) {
           case 400:
-            console.log('400');
             router.push('/oauth/failed');
             break;
           case 401:


### PR DESCRIPTION
## 개요 💡

로그인 failed 페이지를 추가했습니다.

## 작업내용 ⌨️

로그인 failed 페이지를 추가했습니다.
사용자들이 oauth를 사용할때 토큰이 만료되어도 별다른 조치를 취하지 않아 보다 직관적으로 알리고자 합니다.

> 토큰 만료

추후에 해당 사항에 대해서 다뤄보고 지금은 임시로라도 조치를 취하겠습니다.

## 스크린샷/동영상 📸

https://github.com/user-attachments/assets/d54c0a5f-21e4-4ba3-a938-e31da3f922d3

