### PR TITLE
[update] 서비스 명칭 노출 시 스켈레톤 스크린 추가

### DIFF
--- a/apps/client/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
+++ b/apps/client/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
@@ -11,11 +11,15 @@ import { toast } from 'sonner';
 const OAuthAuthorizeForm = () => {
   const [serviceName, setServiceName] = useState<string | undefined>();
   const [isPending, setIsPending] = useState(false);
+  const [isLoadingServiceName, setIsLoadingServiceName] = useState(true);
   const searchParams = useSearchParams();
   const token = searchParams.get('token');
 
   useEffect(() => {
-    if (!token) return;
+    if (!token) {
+      setIsLoadingServiceName(false);
+      return;
+    }
 
     fetch(`/api/oauth/sessions/${token}`)
       .then((res) => res.json())
@@ -26,6 +30,9 @@ const OAuthAuthorizeForm = () => {
       })
       .catch((error) => {
         console.error('서비스 이름 조회 실패:', error);
+      })
+      .finally(() => {
+        setIsLoadingServiceName(false);
       });
   }, [token]);
 
@@ -97,6 +104,7 @@ const OAuthAuthorizeForm = () => {
         isPending={isPending}
         signupHref="/signup"
         serviceName={serviceName || undefined}
+        isLoadingServiceName={isLoadingServiceName}
       />
     </div>
   );

--- a/packages/shared/src/ui/SignInForm/index.tsx
+++ b/packages/shared/src/ui/SignInForm/index.tsx
@@ -17,6 +17,7 @@ import {
   FormErrorMessage,
   Input,
   Label,
+  Skeleton,
 } from '@repo/shared/ui';
 import { cn } from '@repo/shared/utils';
 import { Database, Eye, EyeOff } from 'lucide-react';
@@ -32,9 +33,10 @@ interface SignInFormProps {
   isPending?: boolean;
   signupHref?: string;
   serviceName?: string;
+  isLoadingServiceName?: boolean;
 }
 
-const SignInForm = ({ onSubmit, isPending = false, signupHref, serviceName }: SignInFormProps) => {
+const SignInForm = ({ onSubmit, isPending = false, signupHref, serviceName, isLoadingServiceName = false }: SignInFormProps) => {
   const [showPassword, setShowPassword] = useState(false);
 
   const {
@@ -61,17 +63,21 @@ const SignInForm = ({ onSubmit, isPending = false, signupHref, serviceName }: Si
         </div>
         <div>
           <CardTitle className={cn('text-3xl')}>로그인</CardTitle>
-          <CardDescription className={cn('mt-2')}>
-            DataGSM 계정으로{' '}
-            {serviceName ? (
-              <>
-                <strong className={cn('text-primary')}>{serviceName}</strong>에{' '}
-              </>
-            ) : (
-              ''
-            )}
-            로그인하세요
-          </CardDescription>
+          {isLoadingServiceName ? (
+            <Skeleton className={cn('mt-2 mx-auto h-4 w-64')} />
+          ) : (
+            <CardDescription className={cn('mt-2')}>
+              DataGSM 계정으로{' '}
+              {serviceName ? (
+                <>
+                  <strong className={cn('text-primary')}>{serviceName}</strong>에{' '}
+                </>
+              ) : (
+                ''
+              )}
+              로그인하세요
+            </CardDescription>
+          )}
         </div>
       </CardHeader>
 


### PR DESCRIPTION
## 개요 💡

서비스명을 불러올 때 스켈레톤 스크린을 노출하도록 하였습니다.

## 작업내용 ⌨️

로그인 시 서비스 명칭이 노출될때 조금 느리게 보여지는 것 같이 이것을 스켈레톤 스크린으로 가리도록 변경했습니다.

pre-fetch나 현재 Fetch API로 구현되어 있는 것을 Axios,TanStack으로 바꾸는것을 고려하였지만 pre-fetch는 token이 필요한 비즈니스 플로우 상 불가능하며 Axios,TanStack으로 바꾸고 캐싱을 해두는 것은 사용자가 같은 로그인 페이지를 새로고침을 하는 경우에 곧바로 렌더링되는 점에서 사용자 경험이 부드러울 수 있지만 실질적으로 새로고침보단 로그인 페이지는 1회만 접속하는 경우가 많다고 생각하여 이러한 방식을 적용하였습니다.

## 스크린샷/동영상 📸

**Before**

https://github.com/user-attachments/assets/4d6289aa-9175-4c61-b587-10c2e452a0b0

**After**

https://github.com/user-attachments/assets/b74cf47e-1f37-45ac-804b-ee2f1dd6c627


## 리뷰 요청사항 👀

특별히 무조건 머지해야 한다기 보단 제안 느낌으로 간단히 만들어본 것이라 검토부탁드리겠습니다!
