### PR TITLE
[docs] oauth-react sdk에서 추가된 기능 docs에 반영

### DIFF
--- a/apps/docs/src/app/oauth/sdk/react/page.mdx
+++ b/apps/docs/src/app/oauth/sdk/react/page.mdx
@@ -142,6 +142,8 @@ function CustomLoginButton() {
     </button>
   );
 }
+
+export default CustomLoginButton;
 ```
 
 `useOAuth` Hook은 다음 값을 포함하는 객체를 반환합니다.
@@ -186,6 +188,8 @@ function CallbackPage() {
 
   return <div>로그인 중...</div>;
 }
+
+export default CallbackPage;
 ```
 
 ## 문제 해결

--- a/apps/docs/src/app/oauth/sdk/react/page.mdx
+++ b/apps/docs/src/app/oauth/sdk/react/page.mdx
@@ -1,3 +1,5 @@
+import { Shield } from 'lucide-react'
+
 export const metadata = { title: 'React SDK' }
 
 # DataGSM OAuth SDK for React
@@ -6,16 +8,35 @@ export const metadata = { title: 'React SDK' }
 
 **datagsm-oauth-react**는 React 애플리케이션에서 DataGSM OAuth 인증을 쉽고 빠르게 연동할 수 있도록 돕는 공식 SDK입니다.
 
-이 SDK를 사용하면 복잡한 OAuth 리디렉션 흐름을 직접 구현할 필요 없이, 제공되는 React 컴포넌트와 Hook을 통해 간편하게 로그인 기능을 구현할 수 있습니다.
+이 SDK를 사용하면 복잡한 OAuth 리디렉션 흐름을 직접 구현할 필요 없이, 제공되는 React 컴포넌트와 Hook을 통해 간편하게 로그인 기능을 구현할 수 있습니다. 특히 보안이 강화된 PKCE(Proof Key for Code Exchange) 인증 방식을 지원하여 보다 안전한 인증 환경을 구축할 수 있습니다.
+
+<div className="border-l-4 border-blue-500 bg-blue-50 dark:bg-blue-900/20 p-4 rounded my-6">
+  <div className="flex items-start gap-3">
+    <Shield className="h-5 w-5 text-blue-600 dark:text-blue-500 shrink-0 mt-0.5" />
+    <div>
+      <div className="font-semibold text-blue-900 dark:text-blue-100 mb-1">
+        PKCE 사용 권장
+      </div>
+      <div className="text-blue-800 dark:text-blue-200 text-sm">
+        <code className="mx-1 px-1.5 py-0.5 bg-blue-100 dark:bg-blue-800 rounded">datagsm-oauth-react</code>
+        는 auth모드를 'PKCE'로 설정하면 내부적으로
+        <code className="mx-1 px-1.5 py-0.5 bg-blue-100 dark:bg-blue-800 rounded">code_challenge</code>와
+        <code className="mx-1 px-1.5 py-0.5 bg-blue-100 dark:bg-blue-800 rounded">code_challenge_method</code>를 사용하여 Authorization Code 탈취 공격을 방지할 수 있습니다.
+        자세한 내용은 <a href="/oauth/pkce" className="underline font-medium">PKCE 가이드</a>를 참고하세요.
+      </div>
+    </div>
+  </div>
+</div>
+
 
 ### 주요 특징
 
 | 특징 | 설명 |
 | --- | --- |
 | **간편한 연동** | `OAuthProvider`와 `OAuthLoginButton` 컴포넌트만으로 빠르게 로그인 UI를 구성할 수 있습니다. |
+| **PKCE 지원** | 추가적인 설정 없이 `authMode` 변경만으로 PKCE 인증 방식을 적용할 수 있습니다. |
 | **React Hook 지원** | `useOAuth` Hook을 제공하여 커스텀 로그인 버튼이나 로직을 유연하게 작성할 수 있습니다. |
 | **TypeScript 지원** | 모든 컴포넌트와 Hook은 TypeScript로 작성되어 타입 안정성을 보장합니다. |
-| **최소한의 설정** | `clientId`와 `redirectUri`만 설정하면 즉시 사용할 수 있습니다. |
 
 ### 시스템 요구사항
 
@@ -55,6 +76,7 @@ root.render(
     <OAuthProvider
       clientId="YOUR_CLIENT_ID"
       redirectUri="YOUR_REDIRECT_URI"
+      authMode="PKCE"
     >
       <App />
     </OAuthProvider>
@@ -66,11 +88,12 @@ root.render(
 | --- | --- | --- | --- |
 | `clientId` | `string` | 필수 | DataGSM에서 발급받은 클라이언트 ID |
 | `redirectUri` | `string` | 필수 | 로그인 성공 후 리디렉션될 URI |
+| `authMode` | `'STANDARD' \| 'PKCE'` | 선택 | 인증 방식 설정. 기본값은 `'STANDARD'`입니다. |
 | `children` | `ReactNode` | 필수 | `OAuthProvider`의 하위에 렌더링될 React 컴포넌트 |
 
 ### 2. 로그인 버튼 사용
 
-`OAuthLoginButton` 컴포넌트를 사용하여 로그인 버튼을 렌더링할 수 있습니다. 버튼을 클릭하면 자동으로 DataGSM 로그인 페이지로 리다이렉션됩니다.
+`OAuthLoginButton` 컴포넌트를 사용하여 로그인 버튼을 렌더링할 수 있습니다. 버튼을 클릭하면 설정된 `authMode`에 맞춰 자동으로 DataGSM 로그인 페이지로 리다이렉션됩니다.
 
 ```javascript
 // src/App.jsx
@@ -86,15 +109,6 @@ function App() {
 }
 
 export default App;
-```
-
-기본 문구는 "Data GSM 로그인"이며, `children`을 통해 커스텀할 수 있습니다.
-
-```javascript
-<OAuthLoginButton>
-  <span>🚀</span>
-  <span>DataGSM 계정으로 시작하기</span>
-</OAuthLoginButton>
 ```
 
 `OAuthLoginButton`은 표준 HTML `<button>` 태그의 모든 속성을 지원하며, 추가적으로 다음을 props로 받습니다.
@@ -113,36 +127,66 @@ export default App;
 // src/components/CustomLoginButton.jsx
 
 import { useOAuth } from '@themoment-team/datagsm-oauth-react';
-import './CustomLoginButton.css'; // 직접 만든 스타일
 
 function CustomLoginButton() {
-  const { login, clientId, redirectUri } = useOAuth();
+  const { login } = useOAuth();
 
-  const handleLogin = () => {
-    // 로그인 전후로 필요한 로직을 추가할 수 있습니다.
-    console.log('로그인을 시도합니다...', clientId, redirectUri);
-    login();
+  const handleLogin = async () => {
+    // PKCE 모드인 경우 login() 호출 시 code_verifier가 자동 생성되어 sessionStorage에 저장됩니다.
+    await login();
   };
 
   return (
-    <button className="my-custom-button" onClick={handleLogin}>
+    <button onClick={handleLogin}>
       커스텀 로그인 버튼
     </button>
   );
 }
-
-export default CustomLoginButton;
 ```
 
 `useOAuth` Hook은 다음 값을 포함하는 객체를 반환합니다.
 
 | 반환 값 | 타입 | 설명 |
 | --- | --- | --- |
-| `login` | `() => void` | 호출 시 DataGSM OAuth 로그인 페이지로 리디렉션하는 함수 |
+| `login` | `() => Promise<void>` | 호출 시 DataGSM OAuth 로그인 페이지로 리디렉션하는 함수 |
 | `clientId` | `string` | `OAuthProvider`에 전달된 클라이언트 ID |
 | `redirectUri` | `string` | `OAuthProvider`에 전달된 리디렉션 URI |
+| `authMode` | `'STANDARD' \| 'PKCE'` | 현재 설정된 인증 방식 |
+| `getCodeVerifier` | `() => string \| null` | 저장된 PKCE `code_verifier`를 가져오는 함수 |
+| `clearVerifier` | `() => void` | 저장된 PKCE `code_verifier`를 삭제하는 함수 |
 
-**주의:** `useOAuth` Hook과 `OAuthLoginButton` 컴포넌트는 반드시 `OAuthProvider` 하위에서 사용해야 합니다.
+## PKCE 인증 방식 사용하기
+
+PKCE(Proof Key for Code Exchange) 모드를 사용하면 로그인 과정에서 보안을 한층 더 강화할 수 있습니다.
+
+1. `OAuthProvider`의 `authMode`를 `"PKCE"`로 설정합니다.
+2. `login()` 함수가 실행되면 SDK 내부적으로 `code_verifier`를 생성하여 `sessionStorage`에 저장하고, 이에 대응하는 `code_challenge`를 생성하여 인증 서버로 함께 보냅니다.
+3. 리다이렉트된 페이지(Callback URI)에서 백엔드에 액세스 토큰을 요청할 때, `getCodeVerifier()`를 통해 저장된 `code_verifier` 값을 가져와 함께 전달해야 합니다.
+4. 토큰 요청이 완료된 후에는 `clearVerifier()`를 호출하여 저장된 값을 삭제하는 것이 권장됩니다.
+
+```javascript
+// Callback 페이지 예시
+import { useEffect } from 'react';
+import { useOAuth } from '@themoment-team/datagsm-oauth-react';
+
+function CallbackPage() {
+  const { getCodeVerifier, clearVerifier } = useOAuth();
+
+  useEffect(() => {
+    const codeVerifier = getCodeVerifier();
+    const code = new URLSearchParams(window.location.search).get('code');
+
+    if (code && codeVerifier) {
+      // 백엔드 API 호출 시 code와 codeVerifier를 함께 전달
+      fetchAccessToken(code, codeVerifier).finally(() => {
+        clearVerifier(); // 사용 후 정리
+      });
+    }
+  }, []);
+
+  return <div>로그인 중...</div>;
+}
+```
 
 ## 문제 해결
 


### PR DESCRIPTION
## 개요 💡

auth-react sdk에서 추가된 기능 docs에 반영

## 작업내용 ⌨️

* PKCE 모드만 지원하던 이전 SDK에서 PKCE모드를 선택할 수 있게 바꿈으로 인해 DOCS를 수정했습니다.
* `getCodeVerifier`함수와 `clearVerifier`함수의 설명을 추가하였습니다

## 스크린샷/동영상 📸
 
https://github.com/user-attachments/assets/8c8a257f-5179-4649-a163-9fcfd03e597d

