### PR TITLE
[feat] 회원가입 성공 페이지

### DIFF
--- a/apps/client/src/app/signup/success/page.tsx
+++ b/apps/client/src/app/signup/success/page.tsx
@@ -1,0 +1,7 @@
+import { SignUpSuccessPage } from '@/views/success';
+
+const Success = () => {
+  return <SignUpSuccessPage />;
+};
+
+export default Success;

--- a/apps/client/src/middleware.ts
+++ b/apps/client/src/middleware.ts
@@ -7,6 +7,8 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const accessToken = request.cookies.get(COOKIE_KEYS.ACCESS_TOKEN)?.value;
 
+  const publicPaths = ['/signup', '/signin/reset-password', '/signup/success'];
+
   // OAuth callback 감지 (code 파라미터가 있으면 외부 OAuth callback)
   if (request.nextUrl.searchParams.has('code')) {
     return NextResponse.next();
@@ -17,11 +19,7 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  if (
-    pathname === '/signup' ||
-    pathname === '/signin/reset-password' ||
-    pathname === '/signup/success'
-  ) {
+  if (publicPaths.includes(pathname)) {
     return NextResponse.next();
   }
 

--- a/apps/client/src/middleware.ts
+++ b/apps/client/src/middleware.ts
@@ -17,7 +17,11 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  if (pathname === '/signup' || pathname === '/signin/reset-password') {
+  if (
+    pathname === '/signup' ||
+    pathname === '/signin/reset-password' ||
+    pathname === '/signup/success'
+  ) {
     return NextResponse.next();
   }
 

--- a/apps/client/src/views/success/index.ts
+++ b/apps/client/src/views/success/index.ts
@@ -1,0 +1,1 @@
+export * from './ui';

--- a/apps/client/src/views/success/ui/SuccessPage/index.tsx
+++ b/apps/client/src/views/success/ui/SuccessPage/index.tsx
@@ -5,7 +5,7 @@ import { CheckCircle2, ExternalLink } from 'lucide-react';
 
 const SignUpSuccessPage = () => {
   const handleClose = () => {
-    // Try to close the window (works if opened via window.open)
+    // 윈도우 탭 닫아버리기
     window.close();
   };
 

--- a/apps/client/src/views/success/ui/SuccessPage/index.tsx
+++ b/apps/client/src/views/success/ui/SuccessPage/index.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from '@repo/shared/ui';
+import { CheckCircle2, ExternalLink } from 'lucide-react';
+
+const SignUpSuccessPage = () => {
+  const handleClose = () => {
+    // Try to close the window (works if opened via window.open)
+    window.close();
+  };
+
+  return (
+    <div className="bg-background flex min-h-screen items-center justify-center px-4">
+      <Card className="w-full max-w-md text-center">
+        <CardHeader className="space-y-4 pb-4">
+          <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-green-500/10">
+            <CheckCircle2 className="h-10 w-10 text-green-500" />
+          </div>
+          <div className="space-y-2">
+            <CardTitle className="text-2xl">회원가입 완료</CardTitle>
+            <CardDescription className="text-base">
+              DataGSM 계정이 성공적으로 생성되었습니다
+            </CardDescription>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-6">
+          <div className="bg-muted/50 space-y-2 rounded-lg p-4">
+            <p className="text-muted-foreground text-sm">이 창을 닫고 원래 페이지로 돌아가서</p>
+            <p className="text-base font-medium">로그인을 진행해주세요</p>
+          </div>
+
+          <div className="text-muted-foreground flex items-center justify-center gap-2 text-sm">
+            <ExternalLink className="h-4 w-4" />
+            <span>로그인을 시도했던 서비스로 돌아가세요</span>
+          </div>
+
+          <Button onClick={handleClose} variant="outline" className="w-full">
+            이 창 닫기
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default SignUpSuccessPage;

--- a/apps/client/src/views/success/ui/SuccessPage/index.tsx
+++ b/apps/client/src/views/success/ui/SuccessPage/index.tsx
@@ -5,7 +5,6 @@ import { CheckCircle2, ExternalLink } from 'lucide-react';
 
 const SignUpSuccessPage = () => {
   const handleClose = () => {
-    // 윈도우 탭 닫아버리기
     window.close();
   };
 

--- a/apps/client/src/views/success/ui/index.ts
+++ b/apps/client/src/views/success/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as SignUpSuccessPage } from './SuccessPage';

--- a/apps/client/src/widgets/signup/ui/SignUpForm/index.tsx
+++ b/apps/client/src/widgets/signup/ui/SignUpForm/index.tsx
@@ -210,7 +210,7 @@ const SignUpForm = () => {
   const { mutate: signUp, isPending: isSigningUp } = useSignUp({
     onSuccess: () => {
       toast.success('회원가입이 완료되었습니다. 로그인해주세요.');
-      setTimeout(() => router.push('/'), 1500);
+      setTimeout(() => router.push('/signup/success'), 1500);
     },
     onError: (error: unknown) => {
       const statusCode = getApiErrorCode(error);

--- a/apps/client/src/widgets/signup/ui/SignUpForm/index.tsx
+++ b/apps/client/src/widgets/signup/ui/SignUpForm/index.tsx
@@ -209,8 +209,7 @@ const SignUpForm = () => {
 
   const { mutate: signUp, isPending: isSigningUp } = useSignUp({
     onSuccess: () => {
-      toast.success('회원가입이 완료되었습니다. 로그인해주세요.');
-      setTimeout(() => router.push('/signup/success'), 1500);
+      router.push('/signup/success');
     },
     onError: (error: unknown) => {
       const statusCode = getApiErrorCode(error);

--- a/packages/shared/src/ui/SignInForm/index.tsx
+++ b/packages/shared/src/ui/SignInForm/index.tsx
@@ -144,15 +144,15 @@ const SignInForm = ({ onSubmit, isPending = false, signupHref, serviceName }: Si
           {signupHref && (
             <div className="space-y-2 text-center text-sm">
               <p className={cn('text-muted-foreground text-center text-sm')}>
-                계정이 없으신가요?{' '}
-                <a
+                계정이 없으신가요?
+                <Link
+                  href={signupHref}
                   target="_blank"
                   rel="noopener noreferrer"
-                  href={signupHref}
                   className={cn('text-primary font-medium hover:underline')}
                 >
                   회원가입
-                </a>
+                </Link>
               </p>
               <p>
                 <Link

--- a/packages/shared/src/ui/SignInForm/index.tsx
+++ b/packages/shared/src/ui/SignInForm/index.tsx
@@ -145,9 +145,14 @@ const SignInForm = ({ onSubmit, isPending = false, signupHref, serviceName }: Si
             <div className="space-y-2 text-center text-sm">
               <p className={cn('text-muted-foreground text-center text-sm')}>
                 계정이 없으신가요?{' '}
-                <Link href={signupHref} className={cn('text-primary font-medium hover:underline')}>
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={signupHref}
+                  className={cn('text-primary font-medium hover:underline')}
+                >
                   회원가입
-                </Link>
+                </a>
               </p>
               <p>
                 <Link


### PR DESCRIPTION
## 개요 💡

회원가입 성공 페이지

## 작업내용 ⌨️

> 신규 회원가입 시 로그인 페이지가 아닌 DataGSM 웹으로 진행되는 이슈.

회원가입 성공시 성공 페이지로 리다이렉트 되도록 작업했습니다.

## 스크린샷/동영상 📸

https://github.com/user-attachments/assets/2520326d-10da-466b-ba00-bc03b19cd2dd


