### PR TITLE
[feat] API키 및 클라이언트 수정 시 재확인 모달 추가

### DIFF
--- a/apps/client/src/widgets/clients/ui/ClientFormDialog/index.tsx
+++ b/apps/client/src/widgets/clients/ui/ClientFormDialog/index.tsx
@@ -154,15 +154,17 @@ const ClientFormDialog = ({
     const data = pendingFormData.current;
     if (!data || !client) return;
     const redirectUrls = data.redirectUrls.map((item) => item.url);
-    updateClient({
-      clientId: client.id,
-      data: {
-        clientName: data.clientName,
-        serviceName: data.serviceName,
-        redirectUrls,
+    updateClient(
+      {
+        clientId: client.id,
+        data: {
+          clientName: data.clientName,
+          serviceName: data.serviceName,
+          redirectUrls,
+        },
       },
-    });
-    setIsConfirmOpen(false);
+      { onSettled: () => setIsConfirmOpen(false) },
+    );
   };
 
   const isPending = isCreating || isUpdating;

--- a/apps/client/src/widgets/clients/ui/ClientFormDialog/index.tsx
+++ b/apps/client/src/widgets/clients/ui/ClientFormDialog/index.tsx
@@ -1,10 +1,18 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useScopeSelection } from '@repo/shared/hooks';
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
   Button,
   Checkbox,
   Dialog,
@@ -43,6 +51,8 @@ const ClientFormDialog = ({
   onCreateSuccess,
 }: ClientFormDialogProps) => {
   const [internalOpen, setInternalOpen] = useState(false);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const pendingFormData = useRef<ClientFormType | null>(null);
   const isControlled = controlledOpen !== undefined;
   const open = isControlled ? controlledOpen : internalOpen;
   const setOpen = isControlled ? controlledOnOpenChange! : setInternalOpen;
@@ -132,16 +142,27 @@ const ClientFormDialog = ({
         ...data,
         redirectUrls,
       });
-    } else if (mode === 'edit' && client) {
-      updateClient({
-        clientId: client.id,
-        data: {
-          clientName: data.clientName,
-          serviceName: data.serviceName,
-          redirectUrls,
-        },
-      });
     }
+  };
+
+  const onSaveClick = handleSubmit((data) => {
+    pendingFormData.current = data;
+    setIsConfirmOpen(true);
+  });
+
+  const onConfirmSave = () => {
+    const data = pendingFormData.current;
+    if (!data || !client) return;
+    const redirectUrls = data.redirectUrls.map((item) => item.url);
+    updateClient({
+      clientId: client.id,
+      data: {
+        clientName: data.clientName,
+        serviceName: data.serviceName,
+        redirectUrls,
+      },
+    });
+    setIsConfirmOpen(false);
   };
 
   const isPending = isCreating || isUpdating;
@@ -304,9 +325,31 @@ const ClientFormDialog = ({
           )}
 
           <div className={cn('flex justify-end pt-4')}>
-            <Button type="submit" disabled={isPending}>
-              {submitText}
-            </Button>
+            {mode === 'edit' ? (
+              <>
+                <AlertDialog open={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>클라이언트 수정</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        정말로 &apos;{client?.clientName}&apos; 클라이언트 정보를 수정하시겠습니까?
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>취소</AlertDialogCancel>
+                      <AlertDialogAction onClick={onConfirmSave}>저장</AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+                <Button type="button" disabled={isPending} onClick={onSaveClick}>
+                  저장
+                </Button>
+              </>
+            ) : (
+              <Button type="submit" disabled={isPending}>
+                {submitText}
+              </Button>
+            )}
           </div>
         </form>
       </DialogContent>

--- a/packages/shared/src/ui/ApiKeyForm/index.tsx
+++ b/packages/shared/src/ui/ApiKeyForm/index.tsx
@@ -172,33 +172,29 @@ const ApiKeyForm = ({ initialApiKeyData, initialAvailableScope, userRole }: ApiK
 
   const onRenewConfirm = () => {
     if (!pendingFormData) return;
+    const sharedOptions = {
+      onSuccess: (res: ApiKeyResponse) => {
+        queryClient.setQueryData(authQueryKeys.getApiKey(), res);
+        toast.success('갱신에 성공하였습니다.');
+      },
+      onSettled: () => setIsRenewConfirmOpen(false),
+    };
     if (isApiKeyDataEqual) {
-      rotateApiKey(pendingFormData, {
-        onSuccess: (res) => {
-          queryClient.setQueryData(authQueryKeys.getApiKey(), res);
-          toast.success('갱신에 성공하였습니다.');
-        },
-      });
+      rotateApiKey(pendingFormData, sharedOptions);
     } else {
-      updateApiKey(pendingFormData, {
-        onSuccess: (res) => {
-          queryClient.setQueryData(authQueryKeys.getApiKey(), res);
-          toast.success('갱신에 성공하였습니다.');
-        },
-      });
+      updateApiKey(pendingFormData, sharedOptions);
     }
-    setIsRenewConfirmOpen(false);
   };
 
   const onExtendConfirm = () => {
     if (!pendingFormData) return;
     updateApiKey(pendingFormData, {
-      onSuccess: (res) => {
+      onSuccess: (res: ApiKeyResponse) => {
         queryClient.setQueryData(authQueryKeys.getApiKey(), res);
         toast.success('연장에 성공하였습니다.');
       },
+      onSettled: () => setIsExtendConfirmOpen(false),
     });
-    setIsExtendConfirmOpen(false);
   };
 
   if (isLoadingApiKey || isLoadingKeyScope) {

--- a/packages/shared/src/ui/ApiKeyForm/index.tsx
+++ b/packages/shared/src/ui/ApiKeyForm/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { authQueryKeys } from '@repo/shared/api';
@@ -20,6 +20,14 @@ import {
   UserRoleType,
 } from '@repo/shared/types';
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
   Button,
   Card,
   Checkbox,
@@ -42,6 +50,10 @@ interface ApiKeyFormProps {
 
 const ApiKeyForm = ({ initialApiKeyData, initialAvailableScope, userRole }: ApiKeyFormProps) => {
   const queryClient = useQueryClient();
+
+  const [isRenewConfirmOpen, setIsRenewConfirmOpen] = useState(false);
+  const [isExtendConfirmOpen, setIsExtendConfirmOpen] = useState(false);
+  const [pendingFormData, setPendingFormData] = useState<ApiKeyFormType | null>(null);
 
   const { data: availableKeyScope, isLoading: isLoadingKeyScope } = useGetAvailableScope(userRole, {
     initialData: initialAvailableScope,
@@ -145,25 +157,48 @@ const ApiKeyForm = ({ initialApiKeyData, initialAvailableScope, userRole }: ApiK
   const onSubmit = (data: ApiKeyFormType) => {
     if (!apiKeyData?.data?.apiKey) {
       createApiKey(data);
-      return;
     }
+  };
 
+  const onRenewClick = handleSubmit((data) => {
+    setPendingFormData(data);
+    setIsRenewConfirmOpen(true);
+  });
+
+  const onExtendClick = handleSubmit((data) => {
+    setPendingFormData(data);
+    setIsExtendConfirmOpen(true);
+  });
+
+  const onRenewConfirm = () => {
+    if (!pendingFormData) return;
     if (isApiKeyDataEqual) {
-      rotateApiKey(data, {
+      rotateApiKey(pendingFormData, {
         onSuccess: (res) => {
           queryClient.setQueryData(authQueryKeys.getApiKey(), res);
           toast.success('갱신에 성공하였습니다.');
         },
       });
-      return;
+    } else {
+      updateApiKey(pendingFormData, {
+        onSuccess: (res) => {
+          queryClient.setQueryData(authQueryKeys.getApiKey(), res);
+          toast.success('갱신에 성공하였습니다.');
+        },
+      });
     }
+    setIsRenewConfirmOpen(false);
+  };
 
-    updateApiKey(data, {
+  const onExtendConfirm = () => {
+    if (!pendingFormData) return;
+    updateApiKey(pendingFormData, {
       onSuccess: (res) => {
         queryClient.setQueryData(authQueryKeys.getApiKey(), res);
-        toast.success('갱신에 성공하였습니다.');
+        toast.success('연장에 성공하였습니다.');
       },
     });
+    setIsExtendConfirmOpen(false);
   };
 
   if (isLoadingApiKey || isLoadingKeyScope) {
@@ -227,23 +262,67 @@ const ApiKeyForm = ({ initialApiKeyData, initialAvailableScope, userRole }: ApiK
           />
           <Input placeholder="설명을 작성해주세요." {...register('description')} />
           <FormErrorMessage error={errors.description} />
+          {apiKeyData?.data?.apiKey && (
+            <AlertDialog open={isRenewConfirmOpen} onOpenChange={setIsRenewConfirmOpen}>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>API 키 갱신</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {isApiKeyDataEqual
+                      ? '기존 API 키를 폐기하고 새로운 키를 발급합니다. 이 작업은 되돌릴 수 없습니다.'
+                      : 'API 키의 권한 범위와 설명을 수정하여 새로운 키를 발급합니다.'}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>취소</AlertDialogCancel>
+                  <AlertDialogAction onClick={onRenewConfirm}>확인</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
           <div className={cn('flex flex-col gap-2')}>
             <Tooltip className="w-full">
               <TooltipTrigger asChild>
-                <Button
-                  className="w-full"
-                  disabled={isCreatingApiKey || isUpdatingApiKey || isRotatingApiKey}
-                  size="lg"
-                  type="submit"
-                >
-                  {buttonText}
-                </Button>
+                {apiKeyData?.data?.apiKey ? (
+                  <Button
+                    className="w-full"
+                    disabled={isCreatingApiKey || isUpdatingApiKey || isRotatingApiKey}
+                    size="lg"
+                    type="button"
+                    onClick={onRenewClick}
+                  >
+                    {buttonText}
+                  </Button>
+                ) : (
+                  <Button
+                    className="w-full"
+                    disabled={isCreatingApiKey || isUpdatingApiKey || isRotatingApiKey}
+                    size="lg"
+                    type="submit"
+                  >
+                    {buttonText}
+                  </Button>
+                )}
               </TooltipTrigger>
               <TooltipContent>{buttonTooptipText}</TooltipContent>
             </Tooltip>
           </div>
           {isApiKeyDataEqual && (
             <div className={cn('flex flex-col gap-2')}>
+              <AlertDialog open={isExtendConfirmOpen} onOpenChange={setIsExtendConfirmOpen}>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>기한 연장</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      API 키의 만료 기한을 연장합니다.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>취소</AlertDialogCancel>
+                    <AlertDialogAction onClick={onExtendConfirm}>확인</AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
               <Tooltip className="w-full">
                 <TooltipTrigger asChild>
                   <Button
@@ -252,14 +331,7 @@ const ApiKeyForm = ({ initialApiKeyData, initialAvailableScope, userRole }: ApiK
                     size="lg"
                     type="button"
                     variant="outline"
-                    onClick={handleSubmit((data) =>
-                      updateApiKey(data, {
-                        onSuccess: (res) => {
-                          queryClient.setQueryData(authQueryKeys.getApiKey(), res);
-                          toast.success('연장에 성공하였습니다.');
-                        },
-                      }),
-                    )}
+                    onClick={onExtendClick}
                   >
                     기한 연장하기
                   </Button>


### PR DESCRIPTION
## 개요 💡

실수로 버튼을 누르는 것을 방지하기 위해 비가역적 동작(API 키 갱신, 기한 연장, 클라이언트 수정)에 `AlertDialog` 확인 모달을 추가했습니다.

## 작업내용 ⌨️

**`packages/shared/src/ui/ApiKeyForm/index.tsx`**
- "API 키 갱신하기" 버튼 클릭 시 `AlertDialog` 표시 후 확인 시 mutation 실행
  - scope/description 변경 없음: "기존 API 키를 폐기하고 새로운 키를 발급합니다. 이 작업은 되돌릴 수 없습니다."
  - scope/description 변경 있음: "API 키의 권한 범위와 설명을 수정하여 새로운 키를 발급합니다."
- "기한 연장하기" 버튼 클릭 시 `AlertDialog` 표시 후 확인 시 mutation 실행
- API 키 미발급 상태(create)에서는 모달 없이 즉시 생성 유지
- `handleSubmit`을 통해 유효성 검사 후 모달 open → 확인 시 pendingData로 mutation 실행하는 패턴 적용

**`apps/client/src/widgets/clients/ui/ClientFormDialog/index.tsx`**
- edit 모드에서 "저장" 버튼 클릭 시 `AlertDialog` 표시
  - "정말로 '{clientName}' 클라이언트 정보를 수정하시겠습니까?" 문구 표시
- create 모드는 기존과 동일하게 `type="submit"` 유지, 모달 없음
- `pendingFormData`를 `useRef`로 관리하여 불필요한 리렌더링 방지


## 스크린샷/동영상 📸


https://github.com/user-attachments/assets/d480b60e-282e-4a01-b890-7ac0157d9675

