### PR TITLE
[feat] 어드민 페이지에서 드롭다운을 열 때 Auto Focus 추가

### DIFF
--- a/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
+++ b/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
@@ -4,6 +4,11 @@ import { Club, Student } from '@repo/shared/types';
 import {
   Badge,
   Button,
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
   Dialog,
   DialogContent,
   DialogHeader,
@@ -12,6 +17,9 @@ import {
   FormErrorMessage,
   Input,
   Label,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   Select,
   SelectContent,
   SelectItem,
@@ -20,7 +28,7 @@ import {
 } from '@repo/shared/ui';
 import { cn } from '@repo/shared/utils';
 import { useQueryClient } from '@tanstack/react-query';
-import { Pencil, Plus, X } from 'lucide-react';
+import { ChevronDown, Pencil, Plus, X } from 'lucide-react';
 import { Controller, SubmitHandler, UseFormReturn } from 'react-hook-form';
 import { toast } from 'sonner';
 
@@ -66,17 +74,10 @@ const ClubFormDialog = ({
 
   const queryClient = useQueryClient();
   const [searchTerm, setSearchTerm] = useState('');
-  const [isMemberSelectOpen, setIsMemberSelectOpen] = useState(false);
-  const memberSearchRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (isMemberSelectOpen) {
-      const timer = setTimeout(() => {
-        memberSearchRef.current?.querySelector('input')?.focus();
-      });
-      return () => clearTimeout(timer);
-    }
-  }, [isMemberSelectOpen]);
+  const [leaderPopoverOpen, setLeaderPopoverOpen] = useState(false);
+  const [memberPopoverOpen, setMemberPopoverOpen] = useState(false);
+  const leaderSearchRef = useRef<HTMLInputElement>(null);
+  const memberSearchRef = useRef<HTMLInputElement>(null);
 
   const currentLeaderId = watch('leaderId');
 
@@ -211,72 +212,71 @@ const ClubFormDialog = ({
               <Controller
                 control={control}
                 name="leaderId"
-                render={({ field }) => (
-                  <Select
-                    value={field.value?.toString()}
-                    onOpenChange={(v) => {
-                      if (!v) setSearchTerm('');
-                    }}
-                    onValueChange={(value) => {
-                      const id = Number(value);
-                      field.onChange(id);
-
-                      const participantIds = getValues('participantIds') || [];
-                      if (participantIds.includes(id)) {
-                        setValue(
-                          'participantIds',
-                          participantIds.filter((pId) => pId !== id),
-                        );
-                      }
-                      setSearchTerm('');
-                    }}
-                  >
-                    <SelectTrigger>
-                      {field.value ? (
-                        <div className={cn('flex gap-2')}>
-                          {(() => {
-                            const selectedStudent = students?.find(
-                              (s) => s.id === Number(field.value),
-                            );
-                            return selectedStudent
-                              ? `${selectedStudent.studentNumber} ${selectedStudent.name}`
-                              : '부장 선택';
-                          })()}
-                        </div>
-                      ) : (
-                        <SelectValue placeholder="부장 선택" />
-                      )}
-                    </SelectTrigger>
-                    <SelectContent>
-                      <div className={cn('bg-popover sticky top-0 z-10 p-2')}>
-                        <Input
-                          placeholder="이름 또는 학번 검색..."
-                          value={searchTerm}
-                          autoFocus
-                          onChange={(e) => setSearchTerm(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === ' ') e.stopPropagation();
-                            e.stopPropagation();
-                          }}
-                          onPointerDown={(e) => e.stopPropagation()}
-                        />
-                      </div>
-                      <div className={cn('max-h-[200px] overflow-y-auto')}>
-                        {filteredStudents && filteredStudents.length > 0 ? (
-                          filteredStudents.map((student) => (
-                            <SelectItem key={student.id} value={student.id.toString()}>
-                              {student.studentNumber} {student.name}
-                            </SelectItem>
-                          ))
-                        ) : (
-                          <div className={cn('text-muted-foreground p-4 text-center text-sm')}>
-                            검색 결과가 없습니다.
-                          </div>
-                        )}
-                      </div>
-                    </SelectContent>
-                  </Select>
-                )}
+                render={({ field }) => {
+                  const selectedLeader = students?.find((s) => s.id === Number(field.value));
+                  return (
+                    <Popover
+                      open={leaderPopoverOpen}
+                      onOpenChange={(v) => {
+                        setLeaderPopoverOpen(v);
+                        if (!v) setSearchTerm('');
+                      }}
+                    >
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="outline"
+                          role="combobox"
+                          className={cn('w-full justify-between font-normal')}
+                        >
+                          {selectedLeader
+                            ? `${selectedLeader.studentNumber} ${selectedLeader.name}`
+                            : '부장 선택'}
+                          <ChevronDown className={cn('ml-2 h-4 w-4 shrink-0 opacity-50')} />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent
+                        className={cn('w-(--radix-popover-trigger-width) p-0')}
+                        onOpenAutoFocus={(e) => {
+                          e.preventDefault();
+                          leaderSearchRef.current?.focus();
+                        }}
+                      >
+                        <Command shouldFilter={false}>
+                          <CommandInput
+                            ref={leaderSearchRef}
+                            placeholder="이름 또는 학번 검색..."
+                            value={searchTerm}
+                            onValueChange={setSearchTerm}
+                          />
+                          <CommandList>
+                            <CommandEmpty>검색 결과가 없습니다.</CommandEmpty>
+                            {filteredStudents?.map((student) => (
+                              <CommandItem
+                                key={student.id}
+                                value={student.id.toString()}
+                                onSelect={() => {
+                                  const id = student.id;
+                                  field.onChange(id);
+                                  const participantIds = getValues('participantIds') || [];
+                                  if (participantIds.includes(id)) {
+                                    setValue(
+                                      'participantIds',
+                                      participantIds.filter((pId) => pId !== id),
+                                    );
+                                  }
+                                  setSearchTerm('');
+                                  setLeaderPopoverOpen(false);
+                                }}
+                              >
+                                {student.studentNumber} {student.name}
+                              </CommandItem>
+                            ))}
+                          </CommandList>
+                        </Command>
+                      </PopoverContent>
+                    </Popover>
+                  );
+                }}
               />
               <FormErrorMessage error={errors.leaderId} />
             </div>
@@ -287,58 +287,68 @@ const ClubFormDialog = ({
                 control={control}
                 name="participantIds"
                 render={({ field }) => (
-                  <Select
-                    value=""
-                    onOpenChange={(open) => {
-                      setIsMemberSelectOpen(open);
-                      if (!open) setSearchTerm('');
-                    }}
-                    onValueChange={(value) => {
-                      const id = Number(value);
-                      if (Array.isArray(field.value) && !field.value.includes(id)) {
-                        field.onChange([...field.value, id]);
-                      }
-                      setSearchTerm('');
+                  <Popover
+                    open={memberPopoverOpen}
+                    onOpenChange={(v) => {
+                      setMemberPopoverOpen(v);
+                      if (!v) setSearchTerm('');
                     }}
                   >
-                    <SelectTrigger>
-                      <SelectValue placeholder="팀원 추가" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <div ref={memberSearchRef} className={cn('bg-popover sticky top-0 z-10 p-2')}>
-                        <Input
+                    <PopoverTrigger asChild>
+                      <Button
+                        variant="outline"
+                        role="combobox"
+                        className={cn('w-full justify-between font-normal')}
+                      >
+                        팀원 추가
+                        <ChevronDown className={cn('ml-2 h-4 w-4 shrink-0 opacity-50')} />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent
+                      className={cn('w-(--radix-popover-trigger-width) p-0')}
+                      onOpenAutoFocus={(e) => {
+                        e.preventDefault();
+                        memberSearchRef.current?.focus();
+                      }}
+                    >
+                      <Command shouldFilter={false}>
+                        <CommandInput
+                          ref={memberSearchRef}
                           placeholder="이름 또는 학번 검색..."
                           value={searchTerm}
-                          onChange={(e) => setSearchTerm(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === ' ') e.stopPropagation();
-                            e.stopPropagation();
-                          }}
-                          onPointerDown={(e) => e.stopPropagation()}
+                          onValueChange={setSearchTerm}
                         />
-                      </div>
-                      <div className={cn('max-h-[200px] overflow-y-auto')}>
-                        {filteredStudents && filteredStudents.length > 0 ? (
-                          filteredStudents
-                            .filter(
+                        <CommandList>
+                          <CommandEmpty>검색 결과가 없습니다.</CommandEmpty>
+                          {filteredStudents
+                            ?.filter(
                               (s) =>
                                 Array.isArray(field.value) &&
                                 !field.value.includes(s.id) &&
                                 s.id !== Number(currentLeaderId),
                             )
                             .map((student) => (
-                              <SelectItem key={student.id} value={student.id.toString()}>
+                              <CommandItem
+                                key={student.id}
+                                value={student.id.toString()}
+                                onSelect={() => {
+                                  if (
+                                    Array.isArray(field.value) &&
+                                    !field.value.includes(student.id)
+                                  ) {
+                                    field.onChange([...field.value, student.id]);
+                                  }
+                                  setSearchTerm('');
+                                  setMemberPopoverOpen(false);
+                                }}
+                              >
                                 {student.studentNumber} {student.name}
-                              </SelectItem>
-                            ))
-                        ) : (
-                          <div className={cn('text-muted-foreground p-4 text-center text-sm')}>
-                            검색 결과가 없습니다.
-                          </div>
-                        )}
-                      </div>
-                    </SelectContent>
-                  </Select>
+                              </CommandItem>
+                            ))}
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
                 )}
               />
               <FormErrorMessage

--- a/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
+++ b/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { Club, Student } from '@repo/shared/types';
 import {
@@ -66,6 +66,16 @@ const ClubFormDialog = ({
 
   const queryClient = useQueryClient();
   const [searchTerm, setSearchTerm] = useState('');
+  const [isMemberSelectOpen, setIsMemberSelectOpen] = useState(false);
+  const memberSearchRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isMemberSelectOpen) {
+      setTimeout(() => {
+        memberSearchRef.current?.querySelector('input')?.focus();
+      });
+    }
+  }, [isMemberSelectOpen]);
 
   const currentLeaderId = watch('leaderId');
 
@@ -278,8 +288,9 @@ const ClubFormDialog = ({
                 render={({ field }) => (
                   <Select
                     value=""
-                    onOpenChange={(v) => {
-                      if (!v) setSearchTerm('');
+                    onOpenChange={(open) => {
+                      setIsMemberSelectOpen(open);
+                      if (!open) setSearchTerm('');
                     }}
                     onValueChange={(value) => {
                       const id = Number(value);
@@ -293,7 +304,7 @@ const ClubFormDialog = ({
                       <SelectValue placeholder="팀원 추가" />
                     </SelectTrigger>
                     <SelectContent>
-                      <div className={cn('bg-popover sticky top-0 z-10 p-2')}>
+                      <div ref={memberSearchRef} className={cn('bg-popover sticky top-0 z-10 p-2')}>
                         <Input
                           placeholder="이름 또는 학번 검색..."
                           value={searchTerm}

--- a/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
+++ b/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
@@ -71,9 +71,10 @@ const ClubFormDialog = ({
 
   useEffect(() => {
     if (isMemberSelectOpen) {
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         memberSearchRef.current?.querySelector('input')?.focus();
       });
+      return () => clearTimeout(timer);
     }
   }, [isMemberSelectOpen]);
 

--- a/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
+++ b/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
@@ -223,16 +223,19 @@ const ClubFormDialog = ({
                       }}
                     >
                       <PopoverTrigger asChild>
-                        <Button
-                          variant="outline"
+                        <button
+                          type="button"
                           role="combobox"
-                          className={cn('w-full justify-between font-normal')}
+                          className={cn(
+                            'border-input shadow-xs dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 flex h-9 w-full cursor-pointer items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+                            selectedLeader ? 'text-foreground' : 'text-muted-foreground',
+                          )}
                         >
                           {selectedLeader
                             ? `${selectedLeader.studentNumber} ${selectedLeader.name}`
                             : '부장 선택'}
-                          <ChevronDown className={cn('ml-2 h-4 w-4 shrink-0 opacity-50')} />
-                        </Button>
+                          <ChevronDown className={cn('h-4 w-4 shrink-0 opacity-50')} />
+                        </button>
                       </PopoverTrigger>
                       <PopoverContent
                         className={cn('w-(--radix-popover-trigger-width) p-0')}
@@ -295,14 +298,17 @@ const ClubFormDialog = ({
                     }}
                   >
                     <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
+                      <button
+                        type="button"
                         role="combobox"
-                        className={cn('w-full justify-between font-normal')}
+                        className={cn(
+                          'border-input shadow-xs dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 flex h-9 w-full cursor-pointer items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+                          'text-muted-foreground',
+                        )}
                       >
                         팀원 추가
-                        <ChevronDown className={cn('ml-2 h-4 w-4 shrink-0 opacity-50')} />
-                      </Button>
+                        <ChevronDown className={cn('h-4 w-4 shrink-0 opacity-50')} />
+                      </button>
                     </PopoverTrigger>
                     <PopoverContent
                       className={cn('w-(--radix-popover-trigger-width) p-0')}

--- a/apps/admin/src/widgets/projects/ui/ProjectFormDialog/index.tsx
+++ b/apps/admin/src/widgets/projects/ui/ProjectFormDialog/index.tsx
@@ -71,9 +71,10 @@ const ProjectFormDialog = ({
 
   useEffect(() => {
     if (isMemberSelectOpen) {
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         memberSearchRef.current?.querySelector('input')?.focus();
       });
+      return () => clearTimeout(timer);
     }
   }, [isMemberSelectOpen]);
 
@@ -227,7 +228,10 @@ const ProjectFormDialog = ({
                 render={({ field }) => (
                   <Select
                     value=""
-                    onOpenChange={(open) => setIsMemberSelectOpen(open)}
+                    onOpenChange={(open) => {
+                      setIsMemberSelectOpen(open);
+                      if (!open) setSearchTerm('');
+                    }}
                     onValueChange={(value) => {
                       const id = Number(value);
                       if (Array.isArray(field.value) && !field.value.includes(id)) {

--- a/apps/admin/src/widgets/projects/ui/ProjectFormDialog/index.tsx
+++ b/apps/admin/src/widgets/projects/ui/ProjectFormDialog/index.tsx
@@ -233,14 +233,17 @@ const ProjectFormDialog = ({
                     }}
                   >
                     <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
+                      <button
+                        type="button"
                         role="combobox"
-                        className={cn('w-full justify-between font-normal')}
+                        className={cn(
+                          'border-input shadow-xs dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 flex h-9 w-full cursor-pointer items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+                          'text-muted-foreground',
+                        )}
                       >
                         팀원 추가
-                        <ChevronDown className={cn('ml-2 h-4 w-4 shrink-0 opacity-50')} />
-                      </Button>
+                        <ChevronDown className={cn('h-4 w-4 shrink-0 opacity-50')} />
+                      </button>
                     </PopoverTrigger>
                     <PopoverContent
                       className={cn('w-(--radix-popover-trigger-width) p-0')}

--- a/apps/admin/src/widgets/projects/ui/ProjectFormDialog/index.tsx
+++ b/apps/admin/src/widgets/projects/ui/ProjectFormDialog/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { Club, Project, Student } from '@repo/shared/types';
 import {
@@ -66,6 +66,16 @@ const ProjectFormDialog = ({
   } = form;
 
   const [searchTerm, setSearchTerm] = useState('');
+  const [isMemberSelectOpen, setIsMemberSelectOpen] = useState(false);
+  const memberSearchRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isMemberSelectOpen) {
+      setTimeout(() => {
+        memberSearchRef.current?.querySelector('input')?.focus();
+      });
+    }
+  }, [isMemberSelectOpen]);
 
   const filteredStudents = useMemo(() => {
     if (!searchTerm) return students;
@@ -217,6 +227,7 @@ const ProjectFormDialog = ({
                 render={({ field }) => (
                   <Select
                     value=""
+                    onOpenChange={(open) => setIsMemberSelectOpen(open)}
                     onValueChange={(value) => {
                       const id = Number(value);
                       if (Array.isArray(field.value) && !field.value.includes(id)) {
@@ -229,7 +240,7 @@ const ProjectFormDialog = ({
                       <SelectValue placeholder="팀원 추가" />
                     </SelectTrigger>
                     <SelectContent>
-                      <div className={cn('bg-popover sticky top-0 z-10 p-2')}>
+                      <div ref={memberSearchRef} className={cn('bg-popover sticky top-0 z-10 p-2')}>
                         <Input
                           placeholder="이름 또는 학번 검색..."
                           value={searchTerm}

--- a/apps/admin/src/widgets/projects/ui/ProjectFormDialog/index.tsx
+++ b/apps/admin/src/widgets/projects/ui/ProjectFormDialog/index.tsx
@@ -4,6 +4,11 @@ import { Club, Project, Student } from '@repo/shared/types';
 import {
   Badge,
   Button,
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
   Dialog,
   DialogContent,
   DialogHeader,
@@ -12,6 +17,9 @@ import {
   FormErrorMessage,
   Input,
   Label,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   Select,
   SelectContent,
   SelectItem,
@@ -21,7 +29,7 @@ import {
 } from '@repo/shared/ui';
 import { cn } from '@repo/shared/utils';
 import { useQueryClient } from '@tanstack/react-query';
-import { Pencil, Plus, X } from 'lucide-react';
+import { ChevronDown, Pencil, Plus, X } from 'lucide-react';
 import { Controller, SubmitHandler, UseFormReturn } from 'react-hook-form';
 import { toast } from 'sonner';
 
@@ -66,17 +74,8 @@ const ProjectFormDialog = ({
   } = form;
 
   const [searchTerm, setSearchTerm] = useState('');
-  const [isMemberSelectOpen, setIsMemberSelectOpen] = useState(false);
-  const memberSearchRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (isMemberSelectOpen) {
-      const timer = setTimeout(() => {
-        memberSearchRef.current?.querySelector('input')?.focus();
-      });
-      return () => clearTimeout(timer);
-    }
-  }, [isMemberSelectOpen]);
+  const [memberPopoverOpen, setMemberPopoverOpen] = useState(false);
+  const memberSearchRef = useRef<HTMLInputElement>(null);
 
   const filteredStudents = useMemo(() => {
     if (!searchTerm) return students;
@@ -226,55 +225,65 @@ const ProjectFormDialog = ({
                 control={control}
                 name="participantIds"
                 render={({ field }) => (
-                  <Select
-                    value=""
-                    onOpenChange={(open) => {
-                      setIsMemberSelectOpen(open);
-                      if (!open) setSearchTerm('');
-                    }}
-                    onValueChange={(value) => {
-                      const id = Number(value);
-                      if (Array.isArray(field.value) && !field.value.includes(id)) {
-                        field.onChange([...field.value, id]);
-                        setSearchTerm('');
-                      }
+                  <Popover
+                    open={memberPopoverOpen}
+                    onOpenChange={(v) => {
+                      setMemberPopoverOpen(v);
+                      if (!v) setSearchTerm('');
                     }}
                   >
-                    <SelectTrigger>
-                      <SelectValue placeholder="팀원 추가" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <div ref={memberSearchRef} className={cn('bg-popover sticky top-0 z-10 p-2')}>
-                        <Input
+                    <PopoverTrigger asChild>
+                      <Button
+                        variant="outline"
+                        role="combobox"
+                        className={cn('w-full justify-between font-normal')}
+                      >
+                        팀원 추가
+                        <ChevronDown className={cn('ml-2 h-4 w-4 shrink-0 opacity-50')} />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent
+                      className={cn('w-(--radix-popover-trigger-width) p-0')}
+                      onOpenAutoFocus={(e) => {
+                        e.preventDefault();
+                        memberSearchRef.current?.focus();
+                      }}
+                    >
+                      <Command shouldFilter={false}>
+                        <CommandInput
+                          ref={memberSearchRef}
                           placeholder="이름 또는 학번 검색..."
                           value={searchTerm}
-                          onChange={(e) => setSearchTerm(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === ' ') e.stopPropagation();
-                            e.stopPropagation();
-                          }}
-                          onPointerDown={(e) => e.stopPropagation()}
+                          onValueChange={setSearchTerm}
                         />
-                      </div>
-                      <div className={cn('max-h-[200px] overflow-y-auto')}>
-                        {filteredStudents && filteredStudents.length > 0 ? (
-                          filteredStudents
-                            .filter(
+                        <CommandList>
+                          <CommandEmpty>검색 결과가 없습니다.</CommandEmpty>
+                          {filteredStudents
+                            ?.filter(
                               (s) => Array.isArray(field.value) && !field.value.includes(s.id),
                             )
                             .map((student) => (
-                              <SelectItem key={student.id} value={student.id.toString()}>
+                              <CommandItem
+                                key={student.id}
+                                value={student.id.toString()}
+                                onSelect={() => {
+                                  if (
+                                    Array.isArray(field.value) &&
+                                    !field.value.includes(student.id)
+                                  ) {
+                                    field.onChange([...field.value, student.id]);
+                                  }
+                                  setSearchTerm('');
+                                  setMemberPopoverOpen(false);
+                                }}
+                              >
                                 {student.studentNumber} {student.name}
-                              </SelectItem>
-                            ))
-                        ) : (
-                          <div className={cn('text-muted-foreground p-4 text-center text-sm')}>
-                            검색 결과가 없습니다.
-                          </div>
-                        )}
-                      </div>
-                    </SelectContent>
-                  </Select>
+                              </CommandItem>
+                            ))}
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
                 )}
               />
               <FormErrorMessage

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -50,10 +50,12 @@
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "^0.546.0",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.1.13"

--- a/packages/shared/src/ui/Command/index.tsx
+++ b/packages/shared/src/ui/Command/index.tsx
@@ -4,16 +4,12 @@ import * as React from 'react';
 
 import { cn } from '@repo/shared/utils';
 import { Command as CommandPrimitive } from 'cmdk';
-import { SearchIcon } from 'lucide-react';
 
 function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
   return (
     <CommandPrimitive
       data-slot="command"
-      className={cn(
-        'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
-        className,
-      )}
+      className={cn('bg-popover text-popover-foreground flex h-full w-full flex-col', className)}
       {...props}
     />
   );
@@ -24,12 +20,11 @@ function CommandInput({
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Input>) {
   return (
-    <div data-slot="command-input-wrapper" className="flex items-center border-b px-3">
-      <SearchIcon className="mr-2 size-4 shrink-0 opacity-50" />
+    <div data-slot="command-input-wrapper" className="bg-popover sticky top-0 z-10 p-2">
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50',
+          'border-input shadow-xs dark:bg-input/30 placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-sm outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         {...props}
@@ -42,7 +37,7 @@ function CommandList({ className, ...props }: React.ComponentProps<typeof Comman
   return (
     <CommandPrimitive.List
       data-slot="command-list"
-      className={cn('max-h-[200px] scroll-py-1 overflow-y-auto overflow-x-hidden', className)}
+      className={cn('max-h-[200px] overflow-x-hidden overflow-y-auto p-1', className)}
       {...props}
     />
   );
@@ -52,7 +47,7 @@ function CommandEmpty({ ...props }: React.ComponentProps<typeof CommandPrimitive
   return (
     <CommandPrimitive.Empty
       data-slot="command-empty"
-      className="text-muted-foreground py-6 text-center text-sm"
+      className="text-muted-foreground p-4 text-center text-sm"
       {...props}
     />
   );
@@ -63,7 +58,7 @@ function CommandItem({ className, ...props }: React.ComponentProps<typeof Comman
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        'data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*=\'text-\'])]:text-muted-foreground relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg:not([class*=\'size-\'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0',
+        'data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground relative flex w-full cursor-pointer select-none items-center gap-2 rounded-sm py-1.5 pl-2 pr-2 text-sm outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50',
         className,
       )}
       {...props}

--- a/packages/shared/src/ui/Command/index.tsx
+++ b/packages/shared/src/ui/Command/index.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@repo/shared/utils';
+import { Command as CommandPrimitive } from 'cmdk';
+import { SearchIcon } from 'lucide-react';
+
+function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div data-slot="command-input-wrapper" className="flex items-center border-b px-3">
+      <SearchIcon className="mr-2 size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn('max-h-[200px] scroll-py-1 overflow-y-auto overflow-x-hidden', className)}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({ ...props }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="text-muted-foreground py-6 text-center text-sm"
+      {...props}
+    />
+  );
+}
+
+function CommandItem({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        'data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*=\'text-\'])]:text-muted-foreground relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg:not([class*=\'size-\'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Command, CommandEmpty, CommandInput, CommandItem, CommandList };

--- a/packages/shared/src/ui/Popover/index.tsx
+++ b/packages/shared/src/ui/Popover/index.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import * as React from 'react';
+
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import { cn } from '@repo/shared/utils';
+
+function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border p-4 shadow-md outline-none',
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+export { Popover, PopoverContent, PopoverTrigger };

--- a/packages/shared/src/ui/index.ts
+++ b/packages/shared/src/ui/index.ts
@@ -1,4 +1,6 @@
 export * from './Button';
+export * from './Command';
+export * from './Popover';
 export * from './Card';
 export * from './AlertDialog';
 export * from './Badge';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.8
         version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -321,6 +324,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       lucide-react:
         specifier: ^0.546.0
         version: 0.546.0(react@19.2.1)
@@ -1078,6 +1084,19 @@ packages:
 
   '@radix-ui/react-label@2.1.8':
     resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1910,6 +1929,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -4610,6 +4635,29 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.1)
+      aria-hidden: 1.2.6
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -5426,6 +5474,18 @@ snapshots:
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   collapse-white-space@2.1.0: {}
 


### PR DESCRIPTION
## 개요 💡

팀원 추가 드롭다운을 열었을 때 검색 인풋에 커서가 자동으로 이동하지 않는 UX 문제를 수정합니다.

프로젝트 생성·수정 폼(`ProjectFormDialog`)과 동아리 생성·수정 폼(`ClubFormDialog`)의 팀원 추가 섹션에서 드롭다운을 클릭하면 검색창에 바로 타이핑할 수 있도록 자동 포커스를 적용합니다.

## 작업내용 ⌨️

- `ProjectFormDialog` — 팀원 추가 `SelectContent` 내 검색 인풋 자동 포커스 적용
- `ClubFormDialog` — 팀원 추가 `SelectContent` 내 검색 인풋 자동 포커스 적용

**구현 방식**

처음에는 `autoFocus` prop과 `onOpenAutoFocus`를 시도했으나 둘 다 정상 동작하지 않았습니다.

- `autoFocus`: Radix UI Select의 `FocusScope`가 열릴 때 내부적으로 `event.preventDefault()`를 호출해 선택된 아이템으로 포커스를 강제 이동시키기 때문에 덮어써짐
- `onOpenAutoFocus`: `@radix-ui/react-select` v2에는 해당 prop이 존재하지 않음 (`Dialog`, `Popover`와 달리 `Select.Content`는 노출하지 않음)

최종적으로 `Select`의 `onOpenChange`로 열림 상태를 추적하고, `useEffect` + `setTimeout(0)`으로 Radix 내부 포커스 처리가 끝난 뒤 검색 인풋에 포커스를 이동하는 방식을 적용했습니다.

```tsx
const [isMemberSelectOpen, setIsMemberSelectOpen] = useState(false);
const memberSearchRef = useRef<HTMLDivElement>(null);

useEffect(() => {
  if (isMemberSelectOpen) {
    setTimeout(() => {
      memberSearchRef.current?.querySelector('input')?.focus();
    });
  }
}, [isMemberSelectOpen]);
```

## 스크린샷/동영상 📸

> 팀원 추가 드롭다운 클릭 시 검색 인풋에 커서 자동 이동 확인

https://github.com/user-attachments/assets/79b57348-e3dc-4eb2-a680-41ac61c8a3b2


## 리뷰 요청사항 👀

`@radix-ui/react-select`는 검색 인풋이 포함된 드롭다운을 공식적으로 지원하지 않습니다. Radix UI 및 shadcn/ui 팀의 공식 권장 사항은 검색 가능한 드롭다운에 `Select` 대신 **`Popover` + `Command`(cmdk)** 조합을 사용하는 것입니다. `PopoverContent`는 `onOpenAutoFocus`를 정식으로 지원하기 때문에 아래와 같이 깔끔하게 처리됩니다.

```tsx
<PopoverContent onOpenAutoFocus={(e) => {
  e.preventDefault();
  inputRef.current?.focus();
}}>
  <Command>
    <CommandInput ref={inputRef} placeholder="이름 또는 학번 검색..." />
    <CommandList>
      <CommandItem .../>
    </CommandList>
  </Command>
</PopoverContent>
```

현재 PR은 `setTimeout` 기반의 임시 수정으로 동작 자체는 문제없지만, 추후 `Popover` + `Command` 방식으로 리팩터링하는 것을 Radix UI에서 권장하고 있는 것 같습니다. 다만 해당 방식으로 변경 시 이번 PR에서 새로운 컴포넌트 정의와 관련 종속성 추가,다이얼로그 교체 등 PR 규모도 절대적으론 큰 PR이 아닐지라도 규모가 상대적으로 커지는 감이 있고 적절한 작업일지도 확신이 서지 않아 피드백 부탁드리겠습니다.

- [Radix UI Select API — `SelectContent`에 `onOpenAutoFocus` 없음 확인](https://www.radix-ui.com/primitives/docs/components/select)
- [Radix UI GitHub Issue #1334 — "How to implement a searchable Select?" (메인테이너: Select가 아니라 Combobox로 구현해야 한다고 명시)](https://github.com/radix-ui/primitives/issues/1334)
- [Radix UI GitHub Issue #3017 — "Searchable Select Component" (동일한 제한 사항 논의)](https://github.com/radix-ui/primitives/issues/3017)