### PR TITLE
[docs] 디자인 가이드 문서에서 올바르지 않은 문서 메타데이터 수정

### DIFF
--- a/apps/docs/src/app/oauth/design/page.mdx
+++ b/apps/docs/src/app/oauth/design/page.mdx
@@ -1,6 +1,6 @@
 import { Download } from 'lucide-react'
 
-export const metadata = { title: 'DataGSM Docs | Login Button Design' }
+export const metadata = { title: 'Login Button Design' }
 
 # Login Button Design Guidelines
 


### PR DESCRIPTION
## 개요 💡

#113 이슈를 해결합니다.

## 작업내용 ⌨️

디자인 가이드 문서에서 문서 메타태크가 올바르지 않은 형식으로 되어 있어 같은 정보가 중복으로 노출되었습니다. 이를 해결합니다.

## 스크린샷/동영상 📸

<img width="283" height="81" alt="image" src="https://github.com/user-attachments/assets/edcf57c7-42db-42bd-a759-065b2b22dd93" />

## 관련 이슈 🚨

- #113
