### PR TITLE
[fix] Next rewrites 경로 문제 해결

### DIFF
--- a/apps/client/next.config.ts
+++ b/apps/client/next.config.ts
@@ -4,8 +4,8 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return [
       {
-        source: '/api/((?!oauth).+)',
-        destination: `${process.env.NEXT_PUBLIC_API_BASE_URL}/$1`,
+        source: '/api/:path((?!oauth).*)',
+        destination: `${process.env.NEXT_PUBLIC_API_BASE_URL}/:path*`,
       },
     ];
   },


### PR DESCRIPTION
## 개요 💡

Next rewrites 경로 문제를 해결했습니다.

## 작업내용 ⌨️

기존에 사용하던 $1과 ((?!oauth).+) 정규식 문법이 Next.js에서 정상적으로 인식되지 않아 해당 부분을 수정했습니다.

```js
async rewrites() {
  return [
    {
      source: '/api/:path((?!oauth).*)',
      destination: `${process.env.NEXT_PUBLIC_API_BASE_URL}/:path*`,
    },
  ];
},
```