### PR TITLE
[feat] 동아리 정보가 관리하는 필드 추가에 따른 클라이언트 및 기술문서 수정

### DIFF
--- a/apps/admin/src/entities/club/lib/utils.ts
+++ b/apps/admin/src/entities/club/lib/utils.ts
@@ -1,4 +1,4 @@
-import { ClubType } from '@repo/shared/types';
+import { ClubStatus, ClubType } from '@repo/shared/types';
 
 export const getTypeBadgeVariant = (type: ClubType) => {
   switch (type) {
@@ -17,6 +17,28 @@ export const getTypeLabel = (type: ClubType) => {
       return '전공';
     case 'AUTONOMOUS_CLUB':
       return '자율';
+    default:
+      return '-';
+  }
+};
+
+export const getStatusBadgeVariant = (status: ClubStatus) => {
+  switch (status) {
+    case 'ACTIVE':
+      return 'default';
+    case 'ABOLISHED':
+      return 'outline';
+    default:
+      return 'outline';
+  }
+};
+
+export const getStatusLabel = (status: ClubStatus) => {
+  switch (status) {
+    case 'ACTIVE':
+      return '운영중';
+    case 'ABOLISHED':
+      return '폐지';
     default:
       return '-';
   }

--- a/apps/admin/src/entities/club/model/schema.ts
+++ b/apps/admin/src/entities/club/model/schema.ts
@@ -3,17 +3,55 @@ import { z } from 'zod';
 export const ClubFilterSchema = z.object({
   clubName: z.string().optional(),
   clubType: z.string().optional(),
+  status: z.enum(['ACTIVE', 'ABOLISHED']).optional(),
 });
 
 export type ClubFilterType = z.infer<typeof ClubFilterSchema>;
 
-export const AddClubSchema = z.object({
-  name: z.string().min(1, { message: '동아리명을 입력해주세요.' }),
-  type: z.enum(['MAJOR_CLUB', 'AUTONOMOUS_CLUB'], {
-    message: '동아리 종류를 선택해주세요.',
-  }),
-  leaderId: z.number({ message: '동아리 부장을 선택해주세요.' }).min(1),
-  participantIds: z.array(z.number()).min(1, { message: '한 명 이상의 팀원을 선택해주세요.' }),
-});
+export const AddClubSchema = z
+  .object({
+    name: z.string().min(1, { message: '동아리명을 입력해주세요.' }),
+    type: z.enum(['MAJOR_CLUB', 'AUTONOMOUS_CLUB'], {
+      message: '동아리 종류를 선택해주세요.',
+    }),
+    status: z.enum(['ACTIVE', 'ABOLISHED'], {
+      message: '운영 상태를 선택해주세요.',
+    }),
+    foundedYear: z.preprocess(
+      (val) => (typeof val === 'number' && isNaN(val) ? undefined : val),
+      z
+        .number({ message: '설립연도를 입력해주세요.' })
+        .int()
+        .min(1900, { message: '1900년 이후의 연도를 입력해주세요.' }),
+    ),
+    abolishedYear: z.preprocess(
+      (val) => (typeof val === 'number' && isNaN(val) ? undefined : val),
+      z
+        .number({ message: '폐지연도를 입력해주세요.' })
+        .int()
+        .min(1900, { message: '1900년 이후의 연도를 입력해주세요.' })
+        .optional(),
+    ),
+    leaderId: z.number({ message: '동아리 부장을 선택해주세요.' }).min(1).optional(),
+    participantIds: z.array(z.number()),
+  })
+  .refine(
+    (data) => {
+      if (data.status === 'ACTIVE') {
+        return data.leaderId !== undefined && data.leaderId >= 1;
+      }
+      return true;
+    },
+    { message: '동아리 부장을 선택해주세요.', path: ['leaderId'] },
+  )
+  .refine(
+    (data) => {
+      if (data.status === 'ACTIVE') {
+        return data.participantIds.length >= 1;
+      }
+      return true;
+    },
+    { message: '한 명 이상의 팀원을 선택해주세요.', path: ['participantIds'] },
+  );
 
 export type AddClubType = z.infer<typeof AddClubSchema>;

--- a/apps/admin/src/entities/club/model/schema.ts
+++ b/apps/admin/src/entities/club/model/schema.ts
@@ -17,28 +17,22 @@ export const AddClubSchema = z
     status: z.enum(['ACTIVE', 'ABOLISHED'], {
       message: '운영 상태를 선택해주세요.',
     }),
-    foundedYear: z.preprocess(
-      (val) => (typeof val === 'number' && isNaN(val) ? undefined : val),
-      z
-        .number({ message: '설립연도를 입력해주세요.' })
-        .int()
-        .min(1900, { message: '1900년 이후의 연도를 입력해주세요.' }),
-    ),
-    abolishedYear: z.preprocess(
-      (val) => (typeof val === 'number' && isNaN(val) ? undefined : val),
-      z
-        .number({ message: '폐지연도를 입력해주세요.' })
-        .int()
-        .min(1900, { message: '1900년 이후의 연도를 입력해주세요.' })
-        .optional(),
-    ),
+    foundedYear: z
+      .number({ message: '설립연도를 입력해주세요.' })
+      .int()
+      .min(1900, { message: '1900년 이후의 연도를 입력해주세요.' }),
+    abolishedYear: z
+      .number({ message: '폐지연도를 입력해주세요.' })
+      .int()
+      .min(1900, { message: '1900년 이후의 연도를 입력해주세요.' })
+      .optional(),
     leaderId: z.number({ message: '동아리 부장을 선택해주세요.' }).min(1).optional(),
     participantIds: z.array(z.number()),
   })
   .refine(
     (data) => {
       if (data.status === 'ACTIVE') {
-        return data.leaderId !== undefined && data.leaderId >= 1;
+        return data.leaderId !== undefined;
       }
       return true;
     },

--- a/apps/admin/src/views/clubs/model/useGetClubs.ts
+++ b/apps/admin/src/views/clubs/model/useGetClubs.ts
@@ -8,15 +8,16 @@ interface UseGetClubsParams {
   size?: number;
   clubType?: ClubType;
   clubName?: string;
+  status?: string;
 }
 
 export const useGetClubs = (
-  { page, size, clubType, clubName }: UseGetClubsParams,
+  { page, size, clubType, clubName, status }: UseGetClubsParams,
   options?: Omit<UseQueryOptions<ClubListResponse>, 'queryKey' | 'queryFn'>,
 ) =>
   useQuery({
-    queryKey: clubQueryKeys.getClubs(page, size, clubType, clubName),
-    queryFn: () => get<ClubListResponse>(clubUrl.getClubs(page, size, clubType, clubName)),
+    queryKey: clubQueryKeys.getClubs(page, size, clubType, clubName, status),
+    queryFn: () => get<ClubListResponse>(clubUrl.getClubs(page, size, clubType, clubName, status)),
     staleTime: minutesToMs(5),
     gcTime: minutesToMs(10),
     refetchOnMount: false,

--- a/apps/admin/src/views/clubs/ui/ClubsPage/index.tsx
+++ b/apps/admin/src/views/clubs/ui/ClubsPage/index.tsx
@@ -31,6 +31,9 @@ const ClubsPage = () => {
     defaultValues: {
       name: '',
       type: undefined,
+      status: 'ACTIVE',
+      foundedYear: undefined,
+      abolishedYear: undefined,
       leaderId: undefined,
       participantIds: [],
     },
@@ -39,11 +42,13 @@ const ClubsPage = () => {
   const handleEditClub = (club: Club) => {
     setEditingClub(club);
     setIsEditDialogOpen(true);
-    // 수정 시 폼 데이터 초기화 (participants)
     clubForm.reset({
       name: club.name,
       type: club.type,
-      leaderId: club.leader.id,
+      status: club.status,
+      foundedYear: club.foundedYear,
+      abolishedYear: club.abolishedYear,
+      leaderId: club.leader?.id,
       participantIds: club.participants.map((p) => p.id),
     });
   };
@@ -52,6 +57,7 @@ const ClubsPage = () => {
     (): ClubFilterType & { page: number } => ({
       clubName: searchParams.get('clubName') || 'all',
       clubType: searchParams.get('clubType') || 'all',
+      status: (searchParams.get('status') as ClubFilterType['status']) || undefined,
       page: Number(searchParams.get('page')) || 0,
     }),
     [searchParams],
@@ -62,6 +68,7 @@ const ClubsPage = () => {
     defaultValues: {
       clubName: initialValues.clubName,
       clubType: initialValues.clubType,
+      status: initialValues.status,
     },
   });
 
@@ -77,7 +84,9 @@ const ClubsPage = () => {
 
   useEffect(() => {
     const hasChanged =
-      debouncedClubName !== initialValues.clubName || filters.clubType !== initialValues.clubType;
+      debouncedClubName !== initialValues.clubName ||
+      filters.clubType !== initialValues.clubType ||
+      filters.status !== initialValues.status;
 
     if (hasChanged) {
       updateURL(
@@ -91,8 +100,10 @@ const ClubsPage = () => {
   }, [
     debouncedClubName,
     filters.clubType,
+    filters.status,
     initialValues.clubName,
     initialValues.clubType,
+    initialValues.status,
     updateURL,
     filters,
   ]);
@@ -112,6 +123,7 @@ const ClubsPage = () => {
     size: PAGE_SIZE,
     clubName: debouncedClubName !== 'all' ? debouncedClubName : undefined,
     clubType: filters.clubType !== 'all' ? (filters.clubType as ClubType) : undefined,
+    status: filters.status,
   };
 
   const { data: clubsData, isLoading: isLoadingClubs } = useGetClubs(queryParams);

--- a/apps/admin/src/widgets/clubs/ui/ClubFilter/index.tsx
+++ b/apps/admin/src/widgets/clubs/ui/ClubFilter/index.tsx
@@ -41,24 +41,45 @@ const ClubFilter = ({ control }: ClubFilterProps) => {
         />
       </div>
 
-      <div className={cn('flex items-center gap-2')}>
-        <Label className={cn('text-sm')}>타입:</Label>
-        <Controller
-          control={control}
-          name="clubType"
-          render={({ field }) => (
-            <Select value={field.value} onValueChange={field.onChange}>
-              <SelectTrigger className={cn('w-24')}>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">전체</SelectItem>
-                <SelectItem value="MAJOR_CLUB">전공</SelectItem>
-                <SelectItem value="AUTONOMOUS_CLUB">자율</SelectItem>
-              </SelectContent>
-            </Select>
-          )}
-        />
+      <div className={cn('flex items-center gap-4')}>
+        <div className={cn('flex items-center gap-2')}>
+          <Label className={cn('text-sm')}>타입:</Label>
+          <Controller
+            control={control}
+            name="clubType"
+            render={({ field }) => (
+              <Select value={field.value} onValueChange={field.onChange}>
+                <SelectTrigger className={cn('w-24')}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">전체</SelectItem>
+                  <SelectItem value="MAJOR_CLUB">전공</SelectItem>
+                  <SelectItem value="AUTONOMOUS_CLUB">자율</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </div>
+        <div className={cn('flex items-center gap-2')}>
+          <Label className={cn('text-sm')}>상태:</Label>
+          <Controller
+            control={control}
+            name="status"
+            render={({ field }) => (
+              <Select value={field.value ?? 'all'} onValueChange={(v) => field.onChange(v === 'all' ? undefined : v)}>
+                <SelectTrigger className={cn('w-24')}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">전체</SelectItem>
+                  <SelectItem value="ACTIVE">운영중</SelectItem>
+                  <SelectItem value="ABOLISHED">폐지</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </div>
       </div>
     </div>
   );

--- a/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
+++ b/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
@@ -247,7 +247,7 @@ const ClubFormDialog = ({
                 id="foundedYear"
                 type="number"
                 placeholder="설립연도 입력"
-                {...register('foundedYear', { valueAsNumber: true })}
+                {...register('foundedYear', { setValueAs: (v) => (v === '' ? undefined : Number(v)) })}
               />
               <FormErrorMessage error={errors.foundedYear} />
             </div>
@@ -258,7 +258,7 @@ const ClubFormDialog = ({
                   id="abolishedYear"
                   type="number"
                   placeholder="폐지연도 입력"
-                  {...register('abolishedYear', { valueAsNumber: true })}
+                  {...register('abolishedYear', { setValueAs: (v) => (v === '' ? undefined : Number(v)) })}
                 />
                 <FormErrorMessage error={errors.abolishedYear} />
               </div>

--- a/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
+++ b/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
@@ -72,6 +72,8 @@ const ClubFormDialog = ({
     formState: { errors },
   } = form;
 
+  const currentStatus = watch('status');
+
   const queryClient = useQueryClient();
   const [searchTerm, setSearchTerm] = useState('');
   const [leaderPopoverOpen, setLeaderPopoverOpen] = useState(false);
@@ -80,6 +82,13 @@ const ClubFormDialog = ({
   const memberSearchRef = useRef<HTMLInputElement>(null);
 
   const currentLeaderId = watch('leaderId');
+
+  useEffect(() => {
+    if (currentStatus === 'ABOLISHED') {
+      setValue('leaderId', undefined);
+      setValue('participantIds', []);
+    }
+  }, [currentStatus, setValue]);
 
   const filteredStudents = useMemo(() => {
     if (!searchTerm) return students;
@@ -123,13 +132,19 @@ const ClubFormDialog = ({
         reset({
           name: club.name,
           type: club.type,
-          leaderId: club.leader.id,
+          status: club.status,
+          foundedYear: club.foundedYear,
+          abolishedYear: club.abolishedYear,
+          leaderId: club.leader?.id,
           participantIds: club.participants.map((p) => p.id),
         });
       } else if (mode === 'create') {
         reset({
           name: '',
           type: undefined,
+          status: 'ACTIVE',
+          foundedYear: undefined,
+          abolishedYear: undefined,
           leaderId: undefined,
           participantIds: [],
         });
@@ -208,6 +223,47 @@ const ClubFormDialog = ({
               <FormErrorMessage error={errors.type} />
             </div>
             <div className={cn('space-y-2')}>
+              <Label htmlFor="status">운영 상태</Label>
+              <Controller
+                control={control}
+                name="status"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="상태 선택" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="ACTIVE">운영중</SelectItem>
+                      <SelectItem value="ABOLISHED">폐지</SelectItem>
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+              <FormErrorMessage error={errors.status} />
+            </div>
+            <div className={cn('space-y-2')}>
+              <Label htmlFor="foundedYear">설립연도</Label>
+              <Input
+                id="foundedYear"
+                type="number"
+                placeholder="설립연도 입력"
+                {...register('foundedYear', { valueAsNumber: true })}
+              />
+              <FormErrorMessage error={errors.foundedYear} />
+            </div>
+            {currentStatus === 'ABOLISHED' && (
+              <div className={cn('space-y-2')}>
+                <Label htmlFor="abolishedYear">폐지연도</Label>
+                <Input
+                  id="abolishedYear"
+                  type="number"
+                  placeholder="폐지연도 입력"
+                  {...register('abolishedYear', { valueAsNumber: true })}
+                />
+                <FormErrorMessage error={errors.abolishedYear} />
+              </div>
+            )}
+            {currentStatus !== 'ABOLISHED' && <div className={cn('space-y-2')}>
               <Label htmlFor="leaderId">부장</Label>
               <Controller
                 control={control}
@@ -282,9 +338,9 @@ const ClubFormDialog = ({
                 }}
               />
               <FormErrorMessage error={errors.leaderId} />
-            </div>
+            </div>}
 
-            <div className={cn('space-y-2')}>
+            {currentStatus !== 'ABOLISHED' && <div className={cn('space-y-2')}>
               <Label>팀원 추가</Label>
               <Controller
                 control={control}
@@ -360,10 +416,10 @@ const ClubFormDialog = ({
               <FormErrorMessage
                 error={!Array.isArray(errors.participantIds) ? errors.participantIds : undefined}
               />
-            </div>
+            </div>}
           </div>
 
-          <div className={cn('bg-muted/30 flex flex-col gap-6 rounded-xl')}>
+          {currentStatus !== 'ABOLISHED' && <div className={cn('bg-muted/30 flex flex-col gap-6 rounded-xl')}>
             <Label className={cn('text-foreground text-base font-bold')}>팀원</Label>
             <Controller
               control={control}
@@ -438,7 +494,7 @@ const ClubFormDialog = ({
                 );
               }}
             />
-          </div>
+          </div>}
 
           <div className={cn('flex justify-end pt-2')}>
             <Button type="submit" disabled={isPending}>

--- a/apps/admin/src/widgets/clubs/ui/ClubList/index.tsx
+++ b/apps/admin/src/widgets/clubs/ui/ClubList/index.tsx
@@ -24,7 +24,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Pencil, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { getTypeBadgeVariant, getTypeLabel } from '@/entities/club';
+import { getStatusBadgeVariant, getStatusLabel, getTypeBadgeVariant, getTypeLabel } from '@/entities/club';
 import { useDeleteClub } from '@/widgets/clubs';
 
 interface ClubListProps {
@@ -54,6 +54,8 @@ const ClubList = ({ clubs, isLoading, onEdit }: ClubListProps) => {
           <TableRow>
             <TableHead>동아리명</TableHead>
             <TableHead>타입</TableHead>
+            <TableHead>상태</TableHead>
+            <TableHead>설립연도</TableHead>
             <TableHead>부장</TableHead>
             <TableHead className={cn('w-30')}>작업</TableHead>
           </TableRow>
@@ -67,6 +69,12 @@ const ClubList = ({ clubs, isLoading, onEdit }: ClubListProps) => {
                   </TableCell>
                   <TableCell>
                     <Skeleton className={cn('h-5 w-16')} />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className={cn('h-5 w-16')} />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className={cn('h-4 w-12')} />
                   </TableCell>
                   <TableCell>
                     <Skeleton className={cn('h-4 w-24')} />
@@ -85,7 +93,13 @@ const ClubList = ({ clubs, isLoading, onEdit }: ClubListProps) => {
                     </Badge>
                   </TableCell>
                   <TableCell>
-                    {club.leader.studentNumber} {club.leader.name}
+                    <Badge variant={getStatusBadgeVariant(club.status)}>
+                      {getStatusLabel(club.status)}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>{club.foundedYear}</TableCell>
+                  <TableCell>
+                    {club.leader ? `${club.leader.studentNumber} ${club.leader.name}` : '-'}
                   </TableCell>
                   <TableCell>
                     <div className="flex items-center gap-1">

--- a/apps/docs/src/app/api/http/club/page.mdx
+++ b/apps/docs/src/app/api/http/club/page.mdx
@@ -28,16 +28,18 @@ GET /v1/clubs
 
 ### 요청 파라미터
 
-| 파라미터                          | 타입              | 필수 여부 | 설명                                       | 예시           |
-|-------------------------------|-----------------|-------|------------------------------------------|--------------|
-| `clubId`                      | `Long`          | 선택    | 동아리 ID                                   | `1`          |
-| `clubName`                    | `String`        | 선택    | 동아리 이름                                   | `SW개발동아리`    |
-| `clubType`                    | `ClubType`      | 선택    | 동아리 종류 (`MAJOR_CLUB`, `AUTONOMOUS_CLUB`) | `MAJOR_CLUB` |
-| `page`                        | `Int`           | 선택    | 페이지 번호 (기본값: 0)                          | `0`          |
-| `size`                        | `Int`           | 선택    | 페이지 크기 (기본값: 100)                        | `100`        |
-| `includeLeaderInParticipants` | `Boolean`       | 선택    | 부장을 부원 목록에 포함할지 여부                       | `false`      |
-| `sortBy`                      | `ClubSortBy`    | 선택    | 정렬 기준 (ID, NAME, TYPE)                   | `NAME`       |
-| `sortDirection`               | `SortDirection` | 선택    | 정렬 방향 (ASC, DESC) (기본값: ASC)             | `ASC`        |
+| 파라미터                          | 타입              | 필수 여부 | 설명                                                                       | 예시           |
+|-------------------------------|-----------------|-------|--------------------------------------------------------------------------|--------------|
+| `clubId`                      | `Long`          | 선택    | 동아리 ID                                                                   | `1`          |
+| `clubName`                    | `String`        | 선택    | 동아리 이름                                                                   | `SW개발동아리`    |
+| `clubType`                    | `ClubType`      | 선택    | 동아리 종류 (`MAJOR_CLUB`, `AUTONOMOUS_CLUB`)                                 | `MAJOR_CLUB` |
+| `status`                      | `ClubStatus`    | 선택    | 동아리 운영 상태 (`ACTIVE`, `ABOLISHED`)                                        | `ACTIVE`     |
+| `foundedYear`                 | `Int`           | 선택    | 설립연도 필터                                                                  | `2020`       |
+| `page`                        | `Int`           | 선택    | 페이지 번호 (기본값: 0)                                                          | `0`          |
+| `size`                        | `Int`           | 선택    | 페이지 크기 (기본값: 100)                                                        | `100`        |
+| `includeLeaderInParticipants` | `Boolean`       | 선택    | 부장을 부원 목록에 포함할지 여부                                                       | `false`      |
+| `sortBy`                      | `ClubSortBy`    | 선택    | 정렬 기준 (`ID`, `NAME`, `TYPE`, `FOUNDED_YEAR`, `ABOLISHED_YEAR`, `STATUS`) | `NAME`       |
+| `sortDirection`               | `SortDirection` | 선택    | 정렬 방향 (ASC, DESC) (기본값: ASC)                                             | `ASC`        |
 
 ### 응답 형식
 
@@ -64,13 +66,16 @@ GET /v1/clubs
 
 각 동아리 객체는 다음 필드를 포함합니다.
 
-| 필드             | 타입                         | 설명                                       | 예시           |
-|----------------|----------------------------|------------------------------------------|--------------|
-| `id`           | `Long`                     | 동아리 ID                                   | `1`          |
-| `name`         | `String`                   | 동아리 이름                                   | `SW개발동아리`    |
-| `type`         | `ClubType`                 | 동아리 종류 (`MAJOR_CLUB`, `AUTONOMOUS_CLUB`) | `MAJOR_CLUB` |
-| `leader`       | `ParticipantInfoDto?`      | 동아리 부장 데이터 (부장이 없는 경우 `null`)            | -            |
-| `participants` | `List<ParticipantInfoDto>` | 동아리 부원 목록                                | -            |
+| 필드               | 타입                         | 설명                                       | 예시           |
+|------------------|----------------------------|------------------------------------------|--------------|
+| `id`             | `Long`                     | 동아리 ID                                   | `1`          |
+| `name`           | `String`                   | 동아리 이름                                   | `SW개발동아리`    |
+| `type`           | `ClubType`                 | 동아리 종류 (`MAJOR_CLUB`, `AUTONOMOUS_CLUB`) | `MAJOR_CLUB` |
+| `status`         | `ClubStatus`               | 동아리 운영 상태 (`ACTIVE`, `ABOLISHED`)        | `ACTIVE`     |
+| `foundedYear`    | `Int`                      | 설립연도                                     | `2020`       |
+| `abolishedYear`  | `Int?`                     | 폐지연도 (운영중인 경우 `null`)                    | `2024`       |
+| `leader`         | `ParticipantInfoDto?`      | 동아리 부장 데이터 (부장이 없는 경우 `null`)            | -            |
+| `participants`   | `List<ParticipantInfoDto>` | 동아리 부원 목록                                | -            |
 
 ### 부원 데이터 객체 (ParticipantInfoDto)
 
@@ -115,6 +120,9 @@ curl -X GET "https://api.datagsm.com/v1/clubs?sortBy=NAME&sortDirection=ASC&page
         "id": 1,
         "name": "SW개발동아리",
         "type": "MAJOR_CLUB",
+        "status": "ACTIVE",
+        "foundedYear": 2020,
+        "abolishedYear": null,
         "leader": {
           "id": 1,
           "name": "홍길동",
@@ -156,6 +164,9 @@ curl -X GET "https://api.datagsm.com/v1/clubs?sortBy=NAME&sortDirection=ASC&page
         "id": 1,
         "name": "SW개발동아리",
         "type": "MAJOR_CLUB",
+        "status": "ABOLISHED",
+        "foundedYear": 2018,
+        "abolishedYear": 2023,
         "leader": null,
         "participants": []
       }

--- a/packages/shared/src/api/apiUrls.ts
+++ b/packages/shared/src/api/apiUrls.ts
@@ -104,13 +104,14 @@ export const projectUrl = {
 export const clubUrl = {
   putClubById: (clubId: number) => `/v1/clubs/${clubId}`,
   deleteClubById: (clubId: number) => `/v1/clubs/${clubId}`,
-  getClubs: (page?: number, size?: number, type?: ClubType, clubName?: string) => {
+  getClubs: (page?: number, size?: number, type?: ClubType, clubName?: string, status?: string) => {
     const params = new URLSearchParams();
 
     if (page !== undefined) params.append('page', page.toString());
     if (size !== undefined) params.append('size', size.toString());
     if (type != null) params.append('clubType', type);
     if (clubName !== undefined) params.append('clubName', clubName);
+    if (status !== undefined) params.append('status', status);
 
     const queryString = params.toString();
     return queryString ? `/v1/clubs?${queryString}` : '/v1/clubs';

--- a/packages/shared/src/api/queryKeys.ts
+++ b/packages/shared/src/api/queryKeys.ts
@@ -73,8 +73,8 @@ export const projectQueryKeys = {
 export const clubQueryKeys = {
   putClubById: () => ['clubs', 'update'] as const,
   deleteClubById: () => ['clubs', 'delete'] as const,
-  getClubs: (page?: number, size?: number, type?: string, clubName?: string) =>
-    ['clubs', 'list', { page, size, type, clubName }] as const,
+  getClubs: (page?: number, size?: number, type?: string, clubName?: string, status?: string) =>
+    ['clubs', 'list', { page, size, type, clubName, status }] as const,
   postClub: () => ['clubs', 'create'] as const,
   postClubImport: () => ['clubs', 'imports'] as const,
   getClubExport: () => ['clubs', 'exports', 'excel'] as const,

--- a/packages/shared/src/types/club.ts
+++ b/packages/shared/src/types/club.ts
@@ -19,7 +19,7 @@ export interface Club {
   status: ClubStatus;
   foundedYear: number;
   abolishedYear?: number;
-  leader: ClubMember;
+  leader: ClubMember | null;
   participants: ClubMember[];
 }
 

--- a/packages/shared/src/types/club.ts
+++ b/packages/shared/src/types/club.ts
@@ -1,6 +1,7 @@
 import { ApiResponse, StudentMajor, StudentSex } from '@repo/shared/types';
 
 export type ClubType = 'MAJOR_CLUB' | 'AUTONOMOUS_CLUB';
+export type ClubStatus = 'ACTIVE' | 'ABOLISHED';
 
 export interface ClubMember {
   id: number;
@@ -15,6 +16,9 @@ export interface Club {
   id: number;
   name: string;
   type: ClubType;
+  status: ClubStatus;
+  foundedYear: number;
+  abolishedYear?: number;
   leader: ClubMember;
   participants: ClubMember[];
 }


### PR DESCRIPTION
## 개요 💡

- https://github.com/themoment-team/datagsm-server/pull/242
해당 PR에서 작업된 내용을 클라이언트와 기술문서에도 반영합니다.
## 작업내용 ⌨️                                                                                                                                                  
                  
  ### Shared                                                                                                                                                      
  - `Club` 타입에 `status`, `foundedYear`, `abolishedYear` 필드 추가 및 `ClubStatus` 타입 추가                                                                    
  - `clubUrl.getClubs()` / `clubQueryKeys.getClubs()`에 `status` 파라미터 추가                                                                                    
                                                                                                                                                                  
  ### Admin                                                                                                                                                       
  - `ClubFilterSchema`에 `status` 필드 추가                                                                                                                       
  - `AddClubSchema`에 `status`, `foundedYear`, `abolishedYear` 필드 추가                                                                                          
    - `status === 'ACTIVE'`일 때만 `leaderId`, `participantIds` 필수 검증                                                                                         
    - `foundedYear` / `abolishedYear` 빈 입력(NaN) 처리를 위한 `preprocess` 적용                                                                                  
  - `getStatusLabel()`, `getStatusBadgeVariant()` 유틸 함수 추가                                                                                                  
  - `ClubFilter`에 운영 상태 필터 드롭다운 추가 (전체 / 운영중 / 폐지)                                                                                            
  - `ClubList` 테이블에 상태(Badge), 설립연도 컬럼 추가                                                                                                           
  - `ClubFormDialog`에 `status`, `foundedYear` 필드 추가                                                                                                          
    - `status === 'ABOLISHED'` 선택 시 부장·팀원 입력 UI 숨김 및 값 초기화                                                                                        
    - `status === 'ABOLISHED'` 선택 시 `abolishedYear` 입력 필드 표시                                                                                             
  - `useGetClubs` 및 `ClubsPage`에 `status` 필터 파라미터 연동                                                                                                    
                                                                                                                                                                  
  ### Docs                                                                                                                                                        
  - GET /v1/clubs 요청 파라미터에 `status`, `foundedYear` 추가                                                                                                    
  - `sortBy` 옵션에 `FOUNDED_YEAR`, `ABOLISHED_YEAR`, `STATUS` 추가                                                                                               
  - 동아리 응답 스키마에 `status`, `foundedYear`, `abolishedYear` 필드 추가 및 응답 예시 갱신 

## 스크린샷/동영상 📸

동아리 등록에 실패한것은 [서버 PR #254](https://github.com/themoment-team/datagsm-server/pull/254)에서 해결된 서버 이슈로 인한 것입니다.

https://github.com/user-attachments/assets/6b8405d2-2e22-4738-87f8-6a9a7d6e9473


## 관련 이슈 🚨

- https://github.com/themoment-team/datagsm-server/pull/242
