### PR TITLE
[docs] NET SDK 기술문서에 비공식 패키지 안내 및 경고 문구 추가

### DIFF
--- a/apps/docs/src/app/api/sdk/dotnet/page.mdx
+++ b/apps/docs/src/app/api/sdk/dotnet/page.mdx
@@ -1,10 +1,26 @@
+import { AlertTriangle } from 'lucide-react'
+
 export const metadata = { title: '.NET SDK' }
 
 # DataGSM OpenAPI SDK for .NET
 
+<div className="border-l-4 border-yellow-500 bg-yellow-50 dark:bg-yellow-900/20 p-4 rounded my-4">
+  <div className="flex items-start gap-3">
+    <AlertTriangle className="h-5 w-5 text-yellow-500 shrink-0 mt-0.5" />
+    <div>
+      <div className="font-semibold text-yellow-900 dark:text-yellow-100 mb-1">
+        .NET SDK — 비공식 패키지
+      </div>
+      <div className="text-yellow-800 dark:text-yellow-200 text-sm">
+        .NET SDK는 공식 지원 패키지가 아닌 커뮤니티 기여 비공식 패키지입니다. 기능 및 업데이트 지원이 공식 SDK와 다를 수 있으므로 사용 시 유의하시기 바랍니다.
+      </div>
+    </div>
+  </div>
+</div>
+
 ### 개요
 
-**DataGSM OpenAPI SDK for .NET**은 DataGSM API를 .NET 애플리케이션에서 쉽고 안전하게 사용할 수 있도록 설계된 공식 클라이언트 SDK입니다.
+**DataGSM OpenAPI SDK for .NET**은 DataGSM API를 .NET 애플리케이션에서 쉽고 안전하게 사용할 수 있도록 설계된 비공식 커뮤니티 기여 SDK입니다.
 
 이 SDK를 사용하면 복잡한 HTTP 요청을 직접 작성할 필요 없이, 타입 안전한 인터페이스를 통해 학생, 동아리, 프로젝트, NEIS 데이터에 접근할 수 있습니다.
 


### PR DESCRIPTION
## 개요 💡

.NET SDK 기술문서 자체에는 비공식 패키지 안내 문구가 없어 이를 수정하였습니다.

## 작업내용 ⌨️

OpenAPI SDK for .NET의 세부 문서에는 비공식 패키지 안내 문구가 없어 이를 수정하였습니다.
OpenAPI SDK 개요 문서에는 이 점이 잘 명시되었으나 핵심 문서에서는 이것이 누락되어 있었습니다.

## 스크린샷/동영상 📸

<img width="821" height="258" alt="image" src="https://github.com/user-attachments/assets/bf3dfcbe-b5d7-48b6-b454-04aaa39596c3" />
