### PR TITLE
feat: 공통 헤더를 docs/status에 확장하고 네비게이션 링크를 통합

### DIFF
--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -1,6 +1,3 @@
-import { cookies } from 'next/headers';
-
-import { COOKIE_KEYS } from '@repo/shared/constants';
 import { TanStackProvider, ToastProvider } from '@repo/shared/lib';
 import { Header, TooltipProvider } from '@repo/shared/ui';
 import type { Metadata } from 'next';

--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -26,9 +26,6 @@ const RootLayout = async ({
 }: Readonly<{
   children: React.ReactNode;
 }>) => {
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get(COOKIE_KEYS.ACCESS_TOKEN)?.value;
-
   return (
     <html lang="ko">
       <body>

--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -38,7 +38,7 @@ const RootLayout = async ({
         <TanStackProvider>
           <ToastProvider>
             <TooltipProvider>
-              {accessToken && <Header role="client" />}
+              <Header role="client" />
               {children}
             </TooltipProvider>
           </ToastProvider>

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -1,3 +1,5 @@
+import { TanStackProvider } from '@repo/shared/lib';
+import { Header } from '@repo/shared/ui';
 import { cn } from '@repo/shared/utils';
 import type { Metadata } from 'next';
 
@@ -27,12 +29,15 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang="ko">
       <body>
-        <div className={cn('container mx-auto px-4 py-12')}>
-          <div className={cn('mx-auto flex max-w-7xl flex-col lg:flex-row lg:gap-8')}>
-            <DocsSidebar />
-            <main className={cn('min-w-0 flex-1')}>{children}</main>
+        <TanStackProvider>
+          <Header role="docs" />
+          <div className={cn('container mx-auto px-4 py-12')}>
+            <div className={cn('mx-auto flex max-w-7xl flex-col lg:flex-row lg:gap-8')}>
+              <DocsSidebar />
+              <main className={cn('min-w-0 flex-1')}>{children}</main>
+            </div>
           </div>
-        </div>
+        </TanStackProvider>
       </body>
     </html>
   );

--- a/apps/status/src/app/layout.tsx
+++ b/apps/status/src/app/layout.tsx
@@ -1,6 +1,3 @@
-import { cookies } from 'next/headers';
-
-import { COOKIE_KEYS } from '@repo/shared/constants';
 import { TanStackProvider, ToastProvider } from '@repo/shared/lib';
 import { Header, TooltipProvider } from '@repo/shared/ui';
 import type { Metadata } from 'next';
@@ -25,16 +22,13 @@ const RootLayout = async ({
 }: Readonly<{
   children: React.ReactNode;
 }>) => {
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get(COOKIE_KEYS.ACCESS_TOKEN)?.value;
-
   return (
     <html lang="ko">
       <body>
         <TanStackProvider>
           <ToastProvider>
             <TooltipProvider>
-              {accessToken && <Header role="client" />}
+              <Header role="status" />
               {children}
             </TooltipProvider>
           </ToastProvider>

--- a/apps/status/src/views/status/ui/StatusPage/index.tsx
+++ b/apps/status/src/views/status/ui/StatusPage/index.tsx
@@ -9,7 +9,7 @@ interface StatusPageProps {
 
 const StatusPage = ({ initialHealthStatus }: StatusPageProps) => {
   return (
-    <div className="bg-background min-h-screen">
+    <div className="bg-background min-h-[calc(100vh-4.0625rem)]">
       <main className="container mx-auto px-4 py-16">
         <div className="mx-auto max-w-2xl">
           <div className="mb-8 text-center">

--- a/packages/shared/src/constants/navigation.ts
+++ b/packages/shared/src/constants/navigation.ts
@@ -1,10 +1,13 @@
+export const CLIENT_URL = process.env.NEXT_PUBLIC_CLIENT_URL ?? 'http://localhost:3000';
 export const DOCS_URL = process.env.NEXT_PUBLIC_DOCS_URL ?? 'http://localhost:3002';
+export const STATUS_URL = process.env.NEXT_PUBLIC_STATUS_URL ?? 'http://localhost:3003';
 
 export const NAV_LINKS = {
   client: [
     { href: '/', label: 'APIKey' },
     { href: '/clients', label: 'Client' },
     { href: DOCS_URL, label: 'Docs' },
+    { href: STATUS_URL, label: 'Status' },
     { href: '/myinfo', label: 'My' },
   ],
   admin: [
@@ -12,5 +15,19 @@ export const NAV_LINKS = {
     { href: '/clubs', label: '동아리' },
     { href: '/projects', label: '프로젝트' },
     { href: '/api-keys', label: 'API 키' },
+  ],
+  docs: [
+    { href: CLIENT_URL, label: 'APIKey' },
+    { href: `${CLIENT_URL}/clients`, label: 'Client' },
+    { href: '/', label: 'Docs' },
+    { href: STATUS_URL, label: 'Status' },
+    { href: `${CLIENT_URL}/myinfo`, label: 'My' },
+  ],
+  status: [
+    { href: CLIENT_URL, label: 'APIKey' },
+    { href: `${CLIENT_URL}/clients`, label: 'Client' },
+    { href: DOCS_URL, label: 'Docs' },
+    { href: '/', label: 'Status' },
+    { href: `${CLIENT_URL}/myinfo`, label: 'My' },
   ],
 } as const;

--- a/packages/shared/src/ui/Header/index.tsx
+++ b/packages/shared/src/ui/Header/index.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 
-import { COOKIE_KEYS, NAV_LINKS } from '@repo/shared/constants';
+import { CLIENT_URL, COOKIE_KEYS, NAV_LINKS } from '@repo/shared/constants';
 import { Button } from '@repo/shared/ui';
 import { cn, deleteCookie } from '@repo/shared/utils';
 import { useQueryClient } from '@tanstack/react-query';
@@ -11,11 +10,10 @@ import { Database, LogOut } from 'lucide-react';
 import { toast } from 'sonner';
 
 interface HeaderProps {
-  role?: 'admin' | 'client';
+  role?: 'admin' | 'client' | 'docs' | 'status';
 }
 
 const Header = ({ role = 'client' }: HeaderProps) => {
-  const pathname = usePathname();
   const queryClient = useQueryClient();
 
   const handleLogout = () => {
@@ -30,15 +28,12 @@ const Header = ({ role = 'client' }: HeaderProps) => {
     window.location.href = '/';
   };
 
-  const PUBLIC_ROUTES = ['/signup'];
-  if (PUBLIC_ROUTES.includes(pathname)) return null;
-
   const links = NAV_LINKS[role];
 
   return (
     <header className={cn('bg-background sticky top-0 z-50 border-b')}>
       <div className={cn('container mx-auto flex h-16 items-center justify-between px-4')}>
-        <Link href="/" className={cn('flex items-center gap-2 text-lg font-semibold')}>
+        <Link href={CLIENT_URL} className={cn('flex items-center gap-2 text-lg font-semibold')}>
           <div className={cn('bg-primary flex h-8 w-8 items-center justify-center rounded-lg')}>
             <Database className={cn('text-primary-foreground h-5 w-5')} />
           </div>
@@ -55,10 +50,12 @@ const Header = ({ role = 'client' }: HeaderProps) => {
               {link.label}
             </Link>
           ))}
-          <Button variant="outline" size="sm" onClick={handleLogout} className={cn('gap-2')}>
-            <LogOut className={cn('h-4 w-4')} />
-            로그아웃
-          </Button>
+          {role === 'client' || role === 'admin' ? (
+            <Button variant="outline" size="sm" onClick={handleLogout} className={cn('gap-2')}>
+              <LogOut className={cn('h-4 w-4')} />
+              로그아웃
+            </Button>
+          ) : null}
         </nav>
       </div>
     </header>

--- a/packages/shared/src/ui/SignInForm/index.tsx
+++ b/packages/shared/src/ui/SignInForm/index.tsx
@@ -175,7 +175,7 @@ const SignInForm = ({
 
           <div className="space-y-2 text-center text-sm">
             <p className={cn('text-muted-foreground text-center text-sm')}>
-              계정이 없으신가요?
+              계정이 없으신가요?{' '}
               <Link
                 href={signupHref}
                 target="_blank"


### PR DESCRIPTION
## 개요 💡
공통 Header를 docs/status 앱까지 확장해서 서비스 간 이동이 자연스럽도록 정리했습니다.  
기존에는 앱별로 헤더 노출/네비게이션 구성이 달라 사용자 흐름이 끊기는 부분이 있어 이를 통합했습니다.

## 작업내용 ⌨️
- Header role을 client/admin 외 docs/status까지 확장
- 공통 네비게이션 상수에 docs/status 링크 추가 및 URL 상수 정리
- docs, status, client 레이아웃에서 Header 적용 방식 통일
- status 페이지 본문 높이를 헤더 높이 고려하도록 조정