### PR TITLE
[update] 회원가입/비밀번호 재설정 폼 이메일 도메인 강제 제약 추가

### DIFF
--- a/apps/oauth/src/entities/reset-password/model/schema.ts
+++ b/apps/oauth/src/entities/reset-password/model/schema.ts
@@ -2,7 +2,12 @@ import { z } from 'zod';
 
 export const ResetPasswordFormSchema = z
   .object({
-    email: z.string().min(1, { message: '이메일을 입력해주세요.' }),
+    email: z
+      .string()
+      .min(1, { message: '이메일을 입력해주세요.' })
+      .regex(/^[a-zA-Z0-9._-]+$/, {
+        message: '이메일 아이디는 영문, 숫자, ., _, - 만 사용할 수 있습니다.',
+      }),
     code: z
       .string()
       .min(1, { message: '인증 코드를 입력해주세요.' })

--- a/apps/oauth/src/entities/reset-password/model/schema.ts
+++ b/apps/oauth/src/entities/reset-password/model/schema.ts
@@ -2,13 +2,7 @@ import { z } from 'zod';
 
 export const ResetPasswordFormSchema = z
   .object({
-    email: z
-      .string()
-      .min(1, { message: '이메일을 입력해주세요.' })
-      .pipe(z.email({ message: '올바른 이메일 형식이 아닙니다.' }))
-      .refine((email) => email.endsWith('@gsm.hs.kr'), {
-        message: '@gsm.hs.kr 도메인 계정만 사용 가능합니다.',
-      }),
+    email: z.string().min(1, { message: '이메일을 입력해주세요.' }),
     code: z
       .string()
       .min(1, { message: '인증 코드를 입력해주세요.' })

--- a/apps/oauth/src/entities/signup/model/schema.ts
+++ b/apps/oauth/src/entities/signup/model/schema.ts
@@ -2,13 +2,7 @@ import { z } from 'zod';
 
 export const SignUpFormSchema = z
   .object({
-    email: z
-      .string()
-      .min(1, { message: '이메일을 입력해주세요.' })
-      .pipe(z.email({ message: '올바른 이메일 형식이 아닙니다.' }))
-      .refine((email) => email.endsWith('@gsm.hs.kr'), {
-        message: '@gsm.hs.kr 도메인 계정만 사용 가능합니다.',
-      }),
+    email: z.string().min(1, { message: '이메일을 입력해주세요.' }),
     password: z
       .string()
       .min(1, { message: '비밀번호를 입력해주세요.' })

--- a/apps/oauth/src/entities/signup/model/schema.ts
+++ b/apps/oauth/src/entities/signup/model/schema.ts
@@ -2,7 +2,12 @@ import { z } from 'zod';
 
 export const SignUpFormSchema = z
   .object({
-    email: z.string().min(1, { message: '이메일을 입력해주세요.' }),
+    email: z
+      .string()
+      .min(1, { message: '이메일을 입력해주세요.' })
+      .regex(/^[a-zA-Z0-9._-]+$/, {
+        message: '이메일 아이디는 영문, 숫자, ., _, - 만 사용할 수 있습니다.',
+      }),
     password: z
       .string()
       .min(1, { message: '비밀번호를 입력해주세요.' })

--- a/apps/oauth/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
+++ b/apps/oauth/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/widgets/reset-password';
 
 const RESEND_COOLDOWN_MS = minutesToMs(5);
+const EMAIL_DOMAIN = '@gsm.hs.kr';
 const STORAGE_KEY = 'password_reset_verification_timestamp';
 
 const ResetPasswordForm = () => {
@@ -172,7 +173,7 @@ const ResetPasswordForm = () => {
       lastCheckedCode.current !== debouncedCode
     ) {
       lastCheckedCode.current = debouncedCode;
-      checkEmailCode({ email: emailValue, code: debouncedCode });
+      checkEmailCode({ email: `${emailValue}${EMAIL_DOMAIN}`, code: debouncedCode });
     }
   }, [codeSent, debouncedCode, emailValue, checkEmailCode]);
 
@@ -204,7 +205,7 @@ const ResetPasswordForm = () => {
     if (!isEmailValid) return;
 
     const email = getValues('email');
-    sendEmailCode({ email });
+    sendEmailCode({ email: `${email}${EMAIL_DOMAIN}` });
   };
 
   const formatTime = (seconds: number) => {
@@ -223,7 +224,7 @@ const ResetPasswordForm = () => {
       return;
     }
     const { email, code, password } = data;
-    changePassword({ email, code, newPassword: password });
+    changePassword({ email: `${email}${EMAIL_DOMAIN}`, code, newPassword: password });
   };
 
   return (
@@ -248,13 +249,23 @@ const ResetPasswordForm = () => {
             <Label htmlFor="email">이메일</Label>
             <div className={cn('flex gap-2')}>
               <div className={cn('flex-1 space-y-2')}>
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="example@gsm.hs.kr"
-                  {...register('email')}
-                  disabled={remainingTime > 0 || isCodeVerified}
-                />
+                <div className={cn('flex items-center')}>
+                  <Input
+                    id="email"
+                    type="text"
+                    placeholder="이메일을 입력하세요"
+                    {...register('email')}
+                    disabled={remainingTime > 0 || isCodeVerified}
+                    className={cn('rounded-r-none')}
+                  />
+                  <span
+                    className={cn(
+                      'border-input bg-muted text-muted-foreground flex h-9 items-center whitespace-nowrap rounded-r-md border border-l-0 px-3 text-sm',
+                    )}
+                  >
+                    {EMAIL_DOMAIN}
+                  </span>
+                </div>
                 <FormErrorMessage error={errors.email} />
               </div>
               <Button

--- a/apps/oauth/src/widgets/signup/ui/SignUpForm/index.tsx
+++ b/apps/oauth/src/widgets/signup/ui/SignUpForm/index.tsx
@@ -30,6 +30,7 @@ import { useCheckEmailCode, useSendEmailCode, useSignUp } from '@/widgets/signup
 import { PRIVACY_POLICY } from '../../constants/privacyPolicy';
 
 const RESEND_COOLDOWN_MS = minutesToMs(5);
+const EMAIL_DOMAIN = '@gsm.hs.kr';
 const STORAGE_KEY = 'email_verification_timestamp';
 
 const SignUpForm = () => {
@@ -202,7 +203,7 @@ const SignUpForm = () => {
       lastCheckedCode.current !== debouncedCode
     ) {
       lastCheckedCode.current = debouncedCode;
-      checkEmailCode({ email: emailValue, code: debouncedCode });
+      checkEmailCode({ email: `${emailValue}${EMAIL_DOMAIN}`, code: debouncedCode });
     }
   }, [codeSent, debouncedCode, emailValue, checkEmailCode]);
 
@@ -234,7 +235,7 @@ const SignUpForm = () => {
     if (!isEmailValid) return;
 
     const email = getValues('email');
-    sendEmailCode({ email });
+    sendEmailCode({ email: `${email}${EMAIL_DOMAIN}` });
   };
 
   const formatTime = (seconds: number) => {
@@ -253,7 +254,7 @@ const SignUpForm = () => {
       return;
     }
     const { email, password, code } = data;
-    signUp({ email, password, code });
+    signUp({ email: `${email}${EMAIL_DOMAIN}`, password, code });
   };
 
   return (
@@ -280,13 +281,23 @@ const SignUpForm = () => {
             <Label htmlFor="email">이메일</Label>
             <div className={cn('flex gap-2')}>
               <div className={cn('flex-1 space-y-2')}>
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="example@gsm.hs.kr"
-                  {...register('email')}
-                  disabled={remainingTime > 0 || isCodeVerified}
-                />
+                <div className={cn('flex items-center')}>
+                  <Input
+                    id="email"
+                    type="text"
+                    placeholder="이메일을 입력하세요"
+                    {...register('email')}
+                    disabled={remainingTime > 0 || isCodeVerified}
+                    className={cn('rounded-r-none')}
+                  />
+                  <span
+                    className={cn(
+                      'border-input bg-muted text-muted-foreground flex h-9 items-center whitespace-nowrap rounded-r-md border border-l-0 px-3 text-sm',
+                    )}
+                  >
+                    {EMAIL_DOMAIN}
+                  </span>
+                </div>
                 <FormErrorMessage error={errors.email} />
               </div>
               <Button


### PR DESCRIPTION
## 개요 💡

회원가입/비밀번호 재설정시에도 이메일 도메인을 강제하도록 하였습니다.

## 작업내용 ⌨️

로그인 폼에 존재하였던 이메일 도메인 강제 제약을 회원가입과 비밀번호 재설정 폼에도 적용하였습니다.
기존에도 각 폼들에 이메일 도메인 제약이 있었지만 사용자에게 명시적으로 알려주지 못하였으며 동시에 이메일 도메인까지 직접 사용자가 입력해야 하는 불편함이 있었습니다.

뿐만 아니라 UI적 일관성 측면도 부족하다고 판단하여 이와 같은 작업을 진행하였습니다.
## 스크린샷/동영상 📸

https://github.com/user-attachments/assets/48d78a59-d620-4591-a65a-ce3b9d5913a7

