### PR TITLE
[fix] 기술 문서의 사이드바 스타일이 Firefox 계열에서 적용되지 않았던 문제 수정

### DIFF
--- a/apps/docs/src/shared/styles/globals.css
+++ b/apps/docs/src/shared/styles/globals.css
@@ -8,14 +8,14 @@
       scrollbar-width: thin;
       scrollbar-color: var(--border) transparent;
     }
-  }
 
-  .sidebar-scrollbar::-webkit-scrollbar {
-    width: 4px;
-  }
+    &::-webkit-scrollbar {
+      width: 4px;
+    }
 
-  .sidebar-scrollbar::-webkit-scrollbar-thumb {
-    border-radius: 9999px;
-    background-color: var(--border);
+    &::-webkit-scrollbar-thumb {
+      border-radius: 9999px;
+      background-color: var(--border);
+    }
   }
 }

--- a/apps/docs/src/shared/styles/globals.css
+++ b/apps/docs/src/shared/styles/globals.css
@@ -1,3 +1,21 @@
 @import 'tailwindcss';
 @source "../../../../../packages/shared/src";
 @import '../../../../../packages/shared/src/styles/globals.css';
+
+@layer utilities {
+  .sidebar-scrollbar {
+    @supports not selector(::-webkit-scrollbar) {
+      scrollbar-width: thin;
+      scrollbar-color: var(--border) transparent;
+    }
+  }
+
+  .sidebar-scrollbar::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  .sidebar-scrollbar::-webkit-scrollbar-thumb {
+    border-radius: 9999px;
+    background-color: var(--border);
+  }
+}

--- a/apps/docs/src/widgets/docs/ui/DocsSidebar/index.tsx
+++ b/apps/docs/src/widgets/docs/ui/DocsSidebar/index.tsx
@@ -6,9 +6,6 @@ import { Menu, X } from 'lucide-react';
 
 import { SidebarContent } from './SidebarContent';
 
-const scrollbarStyles =
-  '[&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border';
-
 const DocsSidebar = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
@@ -25,7 +22,7 @@ const DocsSidebar = () => {
       </div>
 
       <aside
-        className={`${scrollbarStyles} sticky top-24 hidden max-h-[calc(100vh-7rem)] w-64 shrink-0 overflow-y-auto lg:block`}
+        className={`sidebar-scrollbar sticky top-24 hidden max-h-[calc(100vh-7rem)] w-64 shrink-0 overflow-y-auto lg:block`}
       >
         <h2 className="text-muted-foreground mb-4 text-sm font-semibold">목차</h2>
         <SidebarContent />
@@ -48,7 +45,7 @@ const DocsSidebar = () => {
               </button>
             </div>
 
-            <div className={`${scrollbarStyles} flex-1 overflow-y-auto p-4 pt-4`}>
+            <div className={`sidebar-scrollbar flex-1 overflow-y-auto p-4 pt-4`}>
               <SidebarContent onLinkClick={() => setMobileMenuOpen(false)} />
             </div>
           </aside>


### PR DESCRIPTION
## 개요 💡

독스 모듈의 사이드바 스타일이 파이어폭스 계열 브라우저에서 적용되지 않았던 것을 수정하였습니다

## 작업내용 ⌨️

독스 모듈의 사이드바 스타일이 파이어폭스 계열 브라우저에서 온전히 적용되지 않았습니다. 파이어폭스 계열에서 지원되지 않는 스타일들이었으며 이를 브라우저에 따라 분기처리 하도록 수정하였습니다.

## 스크린샷/동영상 📸


https://github.com/user-attachments/assets/608f043b-4371-4a86-887c-6271decb7e3c

