### PR TITLE
[feat] 사용자 GitHub 관련 데이터 수정 기능 추가

### DIFF
--- a/apps/admin/src/entities/student/model/schema.ts
+++ b/apps/admin/src/entities/student/model/schema.ts
@@ -33,7 +33,7 @@ export const AddStudentSchema = z.object({
     .min(201, { message: '201호 이상으로 입력해주세요.' })
     .max(518, { message: '518호 이하로 입력해주세요.' }),
   specialty: z.string().min(1, { message: '전공을 입력해주세요.' }).nullable().optional(),
-  githubId: z.string().nullable().optional(),
+  githubId: z.preprocess((val) => (val === '' ? null : val), z.string().nullable().optional()),
   majorClubId: z.number({ message: '전공 동아리를 선택해주세요.' }).min(1).nullable(),
   autonomousClubId: z.number({ message: '자율 동아리를 선택해주세요.' }).min(1).nullable(),
 });

--- a/apps/admin/src/entities/student/model/schema.ts
+++ b/apps/admin/src/entities/student/model/schema.ts
@@ -33,6 +33,7 @@ export const AddStudentSchema = z.object({
     .min(201, { message: '201호 이상으로 입력해주세요.' })
     .max(518, { message: '518호 이하로 입력해주세요.' }),
   specialty: z.string().min(1, { message: '전공을 입력해주세요.' }).nullable().optional(),
+  githubId: z.string().nullable().optional(),
   majorClubId: z.number({ message: '전공 동아리를 선택해주세요.' }).min(1).nullable(),
   autonomousClubId: z.number({ message: '자율 동아리를 선택해주세요.' }).min(1).nullable(),
 });

--- a/apps/admin/src/entities/student/model/schema.ts
+++ b/apps/admin/src/entities/student/model/schema.ts
@@ -33,7 +33,7 @@ export const AddStudentSchema = z.object({
     .min(201, { message: '201호 이상으로 입력해주세요.' })
     .max(518, { message: '518호 이하로 입력해주세요.' }),
   specialty: z.string().min(1, { message: '전공을 입력해주세요.' }).nullable().optional(),
-  githubId: z.preprocess((val) => (val === '' ? null : val), z.string().nullable().optional()),
+  githubId: z.string().nullable().optional(),
   majorClubId: z.number({ message: '전공 동아리를 선택해주세요.' }).min(1).nullable(),
   autonomousClubId: z.number({ message: '자율 동아리를 선택해주세요.' }).min(1).nullable(),
 });

--- a/apps/admin/src/widgets/students/ui/StudentFormDialog/index.tsx
+++ b/apps/admin/src/widgets/students/ui/StudentFormDialog/index.tsx
@@ -108,6 +108,7 @@ const StudentFormDialog = ({
             role: student.role,
             dormitoryRoomNumber: student.dormitoryRoom,
             specialty: student.specialty ?? null,
+            githubId: student.githubId ?? null,
             majorClubId: student.majorClub?.id || null,
             autonomousClubId: student.autonomousClub?.id || null,
           }
@@ -128,6 +129,7 @@ const StudentFormDialog = ({
         role: student.role,
         dormitoryRoomNumber: student.dormitoryRoom,
         specialty: student.specialty ?? null,
+        githubId: student.githubId ?? null,
         majorClubId: student.majorClub?.id || null,
         autonomousClubId: student.autonomousClub?.id || null,
       });
@@ -550,6 +552,25 @@ const StudentFormDialog = ({
                     )}
                   />
                   <FormErrorMessage error={errors.specialty} />
+                </>
+              )}
+            </div>
+            <div className={cn('col-span-2 space-y-2')}>
+              <Label className={cn('font-mono text-xs uppercase tracking-widest text-muted-foreground')}>GitHub ID</Label>
+              {isInactive ? (
+                <div
+                  className={cn(
+                    'h-10 w-full cursor-not-allowed rounded-none border border-foreground/30 bg-muted',
+                  )}
+                />
+              ) : (
+                <>
+                  <Input
+                    placeholder="GitHub 아이디 입력"
+                    className={cn('rounded-none border-foreground font-mono')}
+                    {...register('githubId')}
+                  />
+                  <FormErrorMessage error={errors.githubId} />
                 </>
               )}
             </div>

--- a/apps/admin/src/widgets/students/ui/StudentFormDialog/index.tsx
+++ b/apps/admin/src/widgets/students/ui/StudentFormDialog/index.tsx
@@ -568,7 +568,7 @@ const StudentFormDialog = ({
                   <Input
                     placeholder="GitHub 아이디 입력"
                     className={cn('rounded-none border-foreground font-mono')}
-                    {...register('githubId')}
+                    {...register('githubId', { setValueAs: (v) => (v === '' ? null : v) })}
                   />
                   <FormErrorMessage error={errors.githubId} />
                 </>

--- a/apps/client/src/widgets/myinfo/index.ts
+++ b/apps/client/src/widgets/myinfo/index.ts
@@ -1,5 +1,6 @@
 export * from './ui/ProfileInfo';
 export * from './ui/WithdrawalSection';
 export * from './model/useGetMy';
+export * from './model/usePatchMyGithubId';
 export * from './model/usePatchMySpecialty';
 export * from './model/useWithdrawal';

--- a/apps/client/src/widgets/myinfo/model/usePatchMyGithubId.ts
+++ b/apps/client/src/widgets/myinfo/model/usePatchMyGithubId.ts
@@ -1,0 +1,21 @@
+import { studentQueryKeys, studentUrl, patch } from '@repo/shared/api';
+import { BaseApiResponse } from '@repo/shared/types';
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+interface PatchMyGithubIdData {
+  githubId: string | null;
+}
+
+export const usePatchMyGithubId = (
+  options?: Omit<
+    UseMutationOptions<BaseApiResponse, AxiosError, PatchMyGithubIdData>,
+    'mutationKey' | 'mutationFn'
+  >,
+) =>
+  useMutation({
+    mutationKey: studentQueryKeys.patchMyGithubId(),
+    mutationFn: (data: PatchMyGithubIdData) =>
+      patch<BaseApiResponse>(studentUrl.patchMyGithubId(), data),
+    ...options,
+  });

--- a/apps/client/src/widgets/myinfo/ui/ProfileInfo/index.tsx
+++ b/apps/client/src/widgets/myinfo/ui/ProfileInfo/index.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { accountQueryKeys } from '@repo/shared/api';
 import { SPECIALTY_OPTIONS } from '@repo/shared/constants';
 import { MyAccount } from '@repo/shared/types';
 import {
@@ -133,7 +134,7 @@ const SpecialtyCard = ({ currentSpecialty }: { currentSpecialty: string | null }
 
   const { mutate: patchSpecialty, isPending } = usePatchMySpecialty({
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['accounts', 'my'] });
+      queryClient.invalidateQueries({ queryKey: accountQueryKeys.getMy() });
       setIsEditing(false);
       toast.success('전공이 수정되었습니다.');
     },
@@ -263,7 +264,7 @@ const GithubIdCard = ({ currentGithubId }: { currentGithubId: string | null }) =
 
   const { mutate: patchGithubId, isPending } = usePatchMyGithubId({
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['accounts', 'my'] });
+      queryClient.invalidateQueries({ queryKey: accountQueryKeys.getMy() });
       setIsEditing(false);
       toast.success('GitHub ID가 수정되었습니다.');
     },

--- a/apps/client/src/widgets/myinfo/ui/ProfileInfo/index.tsx
+++ b/apps/client/src/widgets/myinfo/ui/ProfileInfo/index.tsx
@@ -17,10 +17,10 @@ import {
 } from '@repo/shared/ui';
 import { cn } from '@repo/shared/utils';
 import { useQueryClient } from '@tanstack/react-query';
-import { Briefcase, GraduationCap, Home, Mail, Pencil, Shield, User, X } from 'lucide-react';
+import { Briefcase, GraduationCap, Home, Link, Mail, Pencil, Shield, User, X } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { usePatchMySpecialty } from '../../model/usePatchMySpecialty';
+import { usePatchMyGithubId, usePatchMySpecialty } from '@/widgets/myinfo';
 
 interface ProfileInfoProps {
   data: MyAccount;
@@ -100,6 +100,9 @@ export const ProfileInfo = ({ data }: ProfileInfoProps) => {
 
       {/* 진로 정보 */}
       <SpecialtyCard currentSpecialty={student.specialty} />
+
+      {/* GitHub 정보 */}
+      <GithubIdCard currentGithubId={student.githubId} />
 
       {/* 기숙사 및 동아리 정보 */}
       <SectionCard title="기숙사 및 동아리" icon={<Home />}>
@@ -227,6 +230,96 @@ const SpecialtyCard = ({ currentSpecialty }: { currentSpecialty: string | null }
                 </SelectContent>
               </Select>
             )}
+            <div className={cn('flex justify-end gap-2')}>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleCancel}
+                disabled={isPending}
+                className={cn('font-mono text-xs')}
+              >
+                취소
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleSave}
+                disabled={isPending}
+                className={cn('font-mono text-xs')}
+              >
+                {isPending ? '저장 중...' : '저장'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </SectionCard>
+  );
+};
+
+const GithubIdCard = ({ currentGithubId }: { currentGithubId: string | null }) => {
+  const queryClient = useQueryClient();
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+
+  const { mutate: patchGithubId, isPending } = usePatchMyGithubId({
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts', 'my'] });
+      setIsEditing(false);
+      toast.success('GitHub ID가 수정되었습니다.');
+    },
+    onError: () => {
+      toast.error('GitHub ID 수정에 실패했습니다.');
+    },
+  });
+
+  const startEdit = () => {
+    setInputValue(currentGithubId ?? '');
+    setIsEditing(true);
+  };
+
+  const handleSave = () => {
+    patchGithubId({ githubId: inputValue.trim() || null });
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+  };
+
+  return (
+    <SectionCard
+      title="GitHub"
+      icon={<Link />}
+      headerAction={
+        !isEditing && (
+          <PixelIconButton size="sm" onClick={startEdit} aria-label="GitHub ID 수정">
+            <Pencil className={cn('h-3 w-3')} />
+          </PixelIconButton>
+        )
+      }
+    >
+      <div className={cn('px-5 py-4')}>
+        {!isEditing ? (
+          currentGithubId ? (
+            <a
+              href={`https://github.com/${currentGithubId}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn('text-sm font-mono underline underline-offset-4')}
+            >
+              {currentGithubId}
+            </a>
+          ) : (
+            <p className={cn('text-sm font-mono text-muted-foreground')}>{'// 미설정'}</p>
+          )
+        ) : (
+          <div className={cn('space-y-3')}>
+            <Input
+              placeholder="GitHub 아이디 입력"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              className={cn('rounded-none border-foreground font-mono')}
+              autoFocus
+            />
             <div className={cn('flex justify-end gap-2')}>
               <Button
                 variant="outline"

--- a/packages/shared/src/api/apiUrls.ts
+++ b/packages/shared/src/api/apiUrls.ts
@@ -42,6 +42,7 @@ export const studentUrl = {
   getStudentExport: () => '/v1/students/exports/excel',
   postGraduateThirdGrade: () => '/v1/students/graduate/third-grade',
   patchMySpecialty: () => '/v1/students/me/specialty',
+  patchMyGithubId: () => '/v1/students/me/github-id',
 } as const;
 
 export const authUrl = {

--- a/packages/shared/src/api/queryKeys.ts
+++ b/packages/shared/src/api/queryKeys.ts
@@ -39,6 +39,7 @@ export const studentQueryKeys = {
   getStudentExport: () => ['students', 'exports', 'excel'] as const,
   postGraduateThirdGrade: () => ['students', 'graduate', 'third-grade'] as const,
   patchMySpecialty: () => ['students', 'me', 'specialty', 'update'] as const,
+  patchMyGithubId: () => ['students', 'me', 'github-id', 'update'] as const,
 } as const;
 
 export const authQueryKeys = {

--- a/packages/shared/src/types/student.ts
+++ b/packages/shared/src/types/student.ts
@@ -22,6 +22,7 @@ export interface Student {
   studentNumber: number;
   major: StudentMajor;
   specialty: string | null;
+  githubId: string | null;
   role: StudentRole;
   dormitoryFloor: number;
   dormitoryRoom: number;


### PR DESCRIPTION
## 개요 💡

- https://github.com/themoment-team/datagsm-server/pull/273 해당 PR의 수정 사항을 웹 클라이언트에서 적절하게 반영합니다.

## 작업내용 ⌨️

사용자가 마이 페이지에서 자신의 Github 정보를 수정할 수 있도록 하며 동시에 어드민 페이지에서 임의로 Github 정보를 수정할 수 있도록 합니다.

## 스크린샷/동영상 📸


https://github.com/user-attachments/assets/9c2da31d-fddd-46e9-be04-625691e7f333


https://github.com/user-attachments/assets/1509b8ff-7962-4d6f-9b7e-4a3903e7a432

