### PR TITLE
[fix] `client`에 `Galmuri` 폰트 추가

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@repo/shared": "workspace:*",
+    "galmuri": "^2.40.3",
     "lucide-react": "^0.546.0",
     "next": "15.5.9",
     "react": "19.2.1",

--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { TanStackProvider, ToastProvider } from '@repo/shared/lib';
 import { Header, TooltipProvider } from '@repo/shared/ui';
 import type { Metadata } from 'next';
 import { DM_Sans, JetBrains_Mono, Press_Start_2P } from 'next/font/google';
+import localFont from 'next/font/local';
 
 import { GoogleAnalytics } from '@/shared/lib';
 import { SoundModeProvider } from '@/shared/sound-mode';
@@ -12,6 +13,12 @@ const pressStart2P = Press_Start_2P({
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-pixel',
+});
+
+const galmuri11 = localFont({
+  src: '../../node_modules/galmuri/dist/Galmuri11-Bold.woff2',
+  display: 'swap',
+  variable: '--font-korean-pixel',
 });
 
 const jetbrainsMono = JetBrains_Mono({
@@ -49,7 +56,7 @@ const RootLayout = async ({
   return (
     <html
       lang="ko"
-      className={`${pressStart2P.variable} ${jetbrainsMono.variable} ${dmSans.variable}`}
+      className={`${pressStart2P.variable} ${galmuri11.variable} ${jetbrainsMono.variable} ${dmSans.variable}`}
     >
       <body>
         {process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS && (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       '@repo/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      galmuri:
+        specifier: ^2.40.3
+        version: 2.40.3
       lucide-react:
         specifier: ^0.546.0
         version: 0.546.0(react@19.2.1)


### PR DESCRIPTION
## 개요 💡

클라이언트의 특정 페이지에서 폰트가 누락되어 있던 것을 수정하였습니다.

## 작업내용 ⌨️

클라이언트의 클라이언트 관리 페이지에서 `클라이언트` 텍스트에 갈무리11 폰트가 적용되지 않아있던 것을 수정하기 위해 모듈에 종속성을 추가하고 사용하도록 설정하였습니다.

## 스크린샷/동영상 📸

<img width="1415" height="968" alt="image" src="https://github.com/user-attachments/assets/3557862a-2a4a-402a-9503-10f049c1b5cc" />
