### PR TITLE
[fix] 학생 동아리 데이터 수정 시 플레이스홀더 넓이 문제 해결

### DIFF
--- a/apps/admin/src/widgets/students/ui/StudentFormDialog/index.tsx
+++ b/apps/admin/src/widgets/students/ui/StudentFormDialog/index.tsx
@@ -416,7 +416,7 @@ const StudentFormDialog = ({
                         }
                         onValueChange={(val) => field.onChange(val === 'none' ? null : Number(val))}
                       >
-                        <SelectTrigger className={cn('w-full border-foreground rounded-none')}>
+                        <SelectTrigger className={cn('w-full border-foreground')}>
                           <SelectValue placeholder="전공 동아리 선택" />
                         </SelectTrigger>
                         <SelectContent>
@@ -462,7 +462,7 @@ const StudentFormDialog = ({
                         }
                         onValueChange={(val) => field.onChange(val === 'none' ? null : Number(val))}
                       >
-                        <SelectTrigger className={cn('w-full border-foreground rounded-none')}>
+                        <SelectTrigger className={cn('w-full border-foreground')}>
                           <SelectValue placeholder="자율 동아리 선택" />
                         </SelectTrigger>
                         <SelectContent>

--- a/apps/admin/src/widgets/students/ui/StudentFormDialog/index.tsx
+++ b/apps/admin/src/widgets/students/ui/StudentFormDialog/index.tsx
@@ -416,7 +416,7 @@ const StudentFormDialog = ({
                         }
                         onValueChange={(val) => field.onChange(val === 'none' ? null : Number(val))}
                       >
-                        <SelectTrigger className={cn('border-foreground rounded-none')}>
+                        <SelectTrigger className={cn('w-full border-foreground rounded-none')}>
                           <SelectValue placeholder="전공 동아리 선택" />
                         </SelectTrigger>
                         <SelectContent>
@@ -462,7 +462,7 @@ const StudentFormDialog = ({
                         }
                         onValueChange={(val) => field.onChange(val === 'none' ? null : Number(val))}
                       >
-                        <SelectTrigger className={cn('border-foreground rounded-none')}>
+                        <SelectTrigger className={cn('w-full border-foreground rounded-none')}>
                           <SelectValue placeholder="자율 동아리 선택" />
                         </SelectTrigger>
                         <SelectContent>


### PR DESCRIPTION
## 개요 💡

학생 데이터 수정 다이얼로그에서 동아리 데이터 플레이스홀더의 넓이가 지나치게 넓어질 수 있던 문제를 수정하였습니다.

## 작업내용 ⌨️

학생 데이터 수정 다이얼로그에서 동아리 데이터 셀렉트 트리거의 넓이에 제한이 없어 값이 길다면 넓이가 무한정 넓어질 수 있던 것을 수정하였습니다.

## 스크린샷/동영상 📸

- **Before**
<img width="509" height="106" alt="2026-04-03_14-47-07" src="https://github.com/user-attachments/assets/86095c55-ce00-4dff-b194-55248c67f157" />

- **After**
<img width="515" height="104" alt="2026-04-03_14-47-30" src="https://github.com/user-attachments/assets/f8390d5f-ac86-4fe7-b329-9909d7c7fe50" />


