### PR TITLE
[fix] 졸업생&자퇴생 상태에서 내 정보 페이지가 올바르게 값을 표현하지 못하던 문제 수정

### DIFF
--- a/apps/client/src/widgets/myinfo/ui/ProfileInfo/index.tsx
+++ b/apps/client/src/widgets/myinfo/ui/ProfileInfo/index.tsx
@@ -113,11 +113,11 @@ export const ProfileInfo = ({ data }: ProfileInfoProps) => {
         <div className={cn('grid grid-cols-2')}>
           <InfoItem
             label="기숙사 호실"
-            value={isInactive || (!student.dormitoryFloor && !student.dormitoryRoom) ? '-' : `${student.dormitoryFloor}층 ${student.dormitoryRoom}호`}
+            value={isInactive || student.dormitoryFloor == null || student.dormitoryRoom == null ? '-' : `${student.dormitoryFloor}층 ${student.dormitoryRoom}호`}
             className={cn('col-span-2')}
           />
-          <InfoItem label="전공동아리" value={student.majorClub?.name || '없음'} />
-          <InfoItem label="자율동아리" value={student.autonomousClub?.name || '없음'} />
+          <InfoItem label="전공동아리" value={isInactive ? '-' : (student.majorClub?.name || '없음')} />
+          <InfoItem label="자율동아리" value={isInactive ? '-' : (student.autonomousClub?.name || '없음')} />
         </div>
       </SectionCard>
 

--- a/apps/client/src/widgets/myinfo/ui/ProfileInfo/index.tsx
+++ b/apps/client/src/widgets/myinfo/ui/ProfileInfo/index.tsx
@@ -37,6 +37,8 @@ const ROLE_MAP: Record<string, string> = {
   GENERAL_STUDENT: '일반학생',
   STUDENT_COUNCIL: '학생회',
   DORMITORY_MANAGER: '기숙사자치위원회',
+  GRADUATE: '졸업생',
+  WITHDRAWN: '자퇴생',
 };
 
 const SEX_MAP: Record<string, string> = {
@@ -47,6 +49,7 @@ const SEX_MAP: Record<string, string> = {
 export const ProfileInfo = ({ data }: ProfileInfoProps) => {
   const { student, email, role } = data;
   const isAdmin = role === 'ROOT' || role === 'ADMIN';
+  const isInactive = student?.role === 'GRADUATE' || student?.role === 'WITHDRAWN';
 
   if (!student) {
     return (
@@ -80,7 +83,7 @@ export const ProfileInfo = ({ data }: ProfileInfoProps) => {
           <div>
             <p className={cn('font-pixel text-[14px]')}>{student.name}</p>
             <div className={cn('mt-2 flex flex-wrap items-center gap-2')}>
-              <span className={cn('border border-foreground/25 px-1.5 py-0.5 text-xs font-mono uppercase')}>{MAJOR_MAP[student.major] || student.major}</span>
+              {student.major && <span className={cn('border border-foreground/25 px-1.5 py-0.5 text-xs font-mono uppercase')}>{MAJOR_MAP[student.major] || student.major}</span>}
               {isAdmin && <span className={cn('border border-destructive/40 px-1.5 py-0.5 text-xs font-mono uppercase text-destructive')}>{role}</span>}
             </div>
           </div>
@@ -91,24 +94,28 @@ export const ProfileInfo = ({ data }: ProfileInfoProps) => {
       <SectionCard title="학적 정보" icon={<GraduationCap />}>
         <div className={cn('grid grid-flow-col grid-rows-3')}>
           <InfoItem label="이름" value={student.name} />
-          <InfoItem label="학과" value={MAJOR_MAP[student.major] || student.major} />
-          <InfoItem label="성별" value={SEX_MAP[student.sex] || student.sex} />
-          <InfoItem label="학년" value={`${student.grade}학년`} />
-          <InfoItem label="반" value={`${student.classNum}반`} />
-          <InfoItem label="번호" value={`${student.number}번`} />
+          <InfoItem label="학과" value={student.major ? (MAJOR_MAP[student.major] || student.major) : '-'} />
+          <InfoItem label="성별" value={student.sex ? (SEX_MAP[student.sex] || student.sex) : '-'} />
+          <InfoItem label="학년" value={isInactive || !student.grade ? '-' : `${student.grade}학년`} />
+          <InfoItem label="반" value={isInactive || !student.classNum ? '-' : `${student.classNum}반`} />
+          <InfoItem label="번호" value={isInactive || !student.number ? '-' : `${student.number}번`} />
         </div>
       </SectionCard>
 
       {/* 진로 정보 */}
-      <SpecialtyCard currentSpecialty={student.specialty} />
+      <SpecialtyCard currentSpecialty={student.specialty} isInactive={isInactive} />
 
       {/* GitHub 정보 */}
-      <GithubIdCard currentGithubId={student.githubId} />
+      <GithubIdCard currentGithubId={student.githubId} isInactive={isInactive} />
 
       {/* 기숙사 및 동아리 정보 */}
       <SectionCard title="기숙사 및 동아리" icon={<Home />}>
         <div className={cn('grid grid-cols-2')}>
-          <InfoItem label="기숙사 호실" value={`${student.dormitoryFloor}층 ${student.dormitoryRoom}호`} className={cn('col-span-2')} />
+          <InfoItem
+            label="기숙사 호실"
+            value={isInactive || (!student.dormitoryFloor && !student.dormitoryRoom) ? '-' : `${student.dormitoryFloor}층 ${student.dormitoryRoom}호`}
+            className={cn('col-span-2')}
+          />
           <InfoItem label="전공동아리" value={student.majorClub?.name || '없음'} />
           <InfoItem label="자율동아리" value={student.autonomousClub?.name || '없음'} />
         </div>
@@ -125,7 +132,7 @@ export const ProfileInfo = ({ data }: ProfileInfoProps) => {
   );
 };
 
-const SpecialtyCard = ({ currentSpecialty }: { currentSpecialty: string | null }) => {
+const SpecialtyCard = ({ currentSpecialty, isInactive }: { currentSpecialty: string | null; isInactive: boolean }) => {
   const queryClient = useQueryClient();
   const [isEditing, setIsEditing] = useState(false);
   const [isCustom, setIsCustom] = useState(false);
@@ -167,7 +174,7 @@ const SpecialtyCard = ({ currentSpecialty }: { currentSpecialty: string | null }
       title="진로 정보"
       icon={<Briefcase />}
       headerAction={
-        !isEditing && (
+        !isEditing && !isInactive && (
           <PixelIconButton size="sm" onClick={startEdit} aria-label="진로 정보 수정">
             <Pencil className={cn('h-3 w-3')} />
           </PixelIconButton>
@@ -257,7 +264,7 @@ const SpecialtyCard = ({ currentSpecialty }: { currentSpecialty: string | null }
   );
 };
 
-const GithubIdCard = ({ currentGithubId }: { currentGithubId: string | null }) => {
+const GithubIdCard = ({ currentGithubId, isInactive }: { currentGithubId: string | null; isInactive: boolean }) => {
   const queryClient = useQueryClient();
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState('');
@@ -291,7 +298,7 @@ const GithubIdCard = ({ currentGithubId }: { currentGithubId: string | null }) =
       title="GitHub"
       icon={<Link />}
       headerAction={
-        !isEditing && (
+        !isEditing && !isInactive && (
           <PixelIconButton size="sm" onClick={startEdit} aria-label="GitHub ID 수정">
             <Pencil className={cn('h-3 w-3')} />
           </PixelIconButton>


### PR DESCRIPTION
## 개요 💡

졸업생 & 자퇴생 처리가 진행되어 특정 값들이 null이 된다면 이를 마이페이지에서 올바르게 출력하지 못하던 문제가 있어 이를 수정하였습니다.
## 작업내용 ⌨️

졸업생 & 자퇴생 처리로 인해 특정 값들이 null이 된다면 이를 마이페이지에서 올바르게 출력하지 못하고 `null`을 그대로 출력하여 사용자 경험에 악영향을 주던 문제가 있었습니다. 이를 null일 시 `-`과 같은 문제로 렌더링하거나 학과 표시를 제거하도록 하고 올바르게 매핑되지 않던 값을 수정하는 작업을 진행하였습니다.

## 스크린샷/동영상 📸
<table>
  <tr>
<th>
<img width="455" height="672" alt="image" src="https://github.com/user-attachments/assets/c9c052ed-72f7-475a-9271-8f524640b1da" />

</th>
    <th>
       
<img width="463" height="656" alt="image" src="https://github.com/user-attachments/assets/6af10022-2e2b-4bb2-b97d-27598122b2e3" />
    </th>
  </tr>
</table>