### PR TITLE
[fix] 어드민 앱에서 동아리 데이터 수정 시 발생하던 논리적인 오류 해결

### DIFF
--- a/apps/admin/src/entities/club/model/schema.ts
+++ b/apps/admin/src/entities/club/model/schema.ts
@@ -21,7 +21,7 @@ export const AddClubSchema = z
       .number({ message: '설립연도를 입력해주세요.' })
       .int()
       .min(1900, { message: '1900년 이후의 연도를 입력해주세요.' }),
-    abolishedYear: z.any().optional(),
+    abolishedYear: z.number().optional(),
     leaderId: z.number({ message: '동아리 부장을 선택해주세요.' }).min(1).optional(),
     participantIds: z.array(z.number()),
   })
@@ -46,12 +46,7 @@ export const AddClubSchema = z
   .superRefine((data, ctx) => {
     if (data.status !== 'ABOLISHED') return;
 
-    if (
-      data.abolishedYear === undefined ||
-      data.abolishedYear === null ||
-      data.abolishedYear === '' ||
-      (typeof data.abolishedYear === 'number' && Number.isNaN(data.abolishedYear))
-    ) {
+    if (data.abolishedYear === undefined) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: '폐지연도를 입력해주세요.',
@@ -60,11 +55,7 @@ export const AddClubSchema = z
       return;
     }
 
-    if (
-      typeof data.abolishedYear !== 'number' ||
-      !Number.isInteger(data.abolishedYear) ||
-      data.abolishedYear < 1900
-    ) {
+    if (!Number.isInteger(data.abolishedYear) || data.abolishedYear < 1900) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: '1900년 이후의 연도를 입력해주세요.',

--- a/apps/admin/src/entities/club/model/schema.ts
+++ b/apps/admin/src/entities/club/model/schema.ts
@@ -21,11 +21,7 @@ export const AddClubSchema = z
       .number({ message: '설립연도를 입력해주세요.' })
       .int()
       .min(1900, { message: '1900년 이후의 연도를 입력해주세요.' }),
-    abolishedYear: z
-      .number({ message: '폐지연도를 입력해주세요.' })
-      .int()
-      .min(1900, { message: '1900년 이후의 연도를 입력해주세요.' })
-      .optional(),
+    abolishedYear: z.any().optional(),
     leaderId: z.number({ message: '동아리 부장을 선택해주세요.' }).min(1).optional(),
     participantIds: z.array(z.number()),
   })
@@ -46,6 +42,35 @@ export const AddClubSchema = z
       return true;
     },
     { message: '한 명 이상의 팀원을 선택해주세요.', path: ['participantIds'] },
-  );
+  )
+  .superRefine((data, ctx) => {
+    if (data.status !== 'ABOLISHED') return;
+
+    if (
+      data.abolishedYear === undefined ||
+      data.abolishedYear === null ||
+      data.abolishedYear === '' ||
+      (typeof data.abolishedYear === 'number' && Number.isNaN(data.abolishedYear))
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '폐지연도를 입력해주세요.',
+        path: ['abolishedYear'],
+      });
+      return;
+    }
+
+    if (
+      typeof data.abolishedYear !== 'number' ||
+      !Number.isInteger(data.abolishedYear) ||
+      data.abolishedYear < 1900
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '1900년 이후의 연도를 입력해주세요.',
+        path: ['abolishedYear'],
+      });
+    }
+  });
 
 export type AddClubType = z.infer<typeof AddClubSchema>;

--- a/apps/admin/src/views/clubs/ui/ClubsPage/index.tsx
+++ b/apps/admin/src/views/clubs/ui/ClubsPage/index.tsx
@@ -49,7 +49,7 @@ const ClubsPage = () => {
       foundedYear: club.foundedYear,
       abolishedYear: club.abolishedYear,
       leaderId: club.leader?.id,
-      participantIds: club.participants.map((p) => p.id),
+      participantIds: club.participants?.map((p) => p.id) ?? [],
     });
   };
 

--- a/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
+++ b/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
@@ -177,17 +177,12 @@ const ClubFormDialog = ({
   };
 
   const onInvalid = (errors: FieldErrors<AddClubType>) => {
-    const firstError =
-      errors.name?.message ||
-      errors.type?.message ||
-      errors.status?.message ||
-      errors.foundedYear?.message ||
-      errors.abolishedYear?.message ||
-      errors.leaderId?.message ||
-      (!Array.isArray(errors.participantIds) ? errors.participantIds?.message : undefined);
+    const firstError = Object.values(errors)
+      .flat()
+      .find((error) => error?.message);
 
-    if (firstError) {
-      toast.error(String(firstError));
+    if (firstError?.message) {
+      toast.error(String(firstError.message));
     }
   };
 

--- a/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
+++ b/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
@@ -29,7 +29,7 @@ import {
 import { cn } from '@repo/shared/utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { ChevronDown, Pencil, Plus, X } from 'lucide-react';
-import { Controller, SubmitHandler, UseFormReturn } from 'react-hook-form';
+import { Controller, FieldErrors, SubmitHandler, UseFormReturn } from 'react-hook-form';
 import { toast } from 'sonner';
 
 import { AddClubType } from '@/entities/club';
@@ -86,7 +86,10 @@ const ClubFormDialog = ({
     if (currentStatus === 'ABOLISHED') {
       setValue('leaderId', undefined);
       setValue('participantIds', []);
+      return;
     }
+
+    setValue('abolishedYear', undefined);
   }, [currentStatus, setValue]);
 
   const filteredStudents = useMemo(() => {
@@ -135,7 +138,7 @@ const ClubFormDialog = ({
           foundedYear: club.foundedYear,
           abolishedYear: club.abolishedYear,
           leaderId: club.leader?.id,
-          participantIds: club.participants.map((p) => p.id),
+          participantIds: club.participants?.map((p) => p.id) ?? [],
         });
       } else if (mode === 'create') {
         reset({
@@ -158,13 +161,33 @@ const ClubFormDialog = ({
   }, [open]);
 
   const onSubmit: SubmitHandler<AddClubType> = (data) => {
+    const normalizedData = {
+      ...data,
+      abolishedYear: data.abolishedYear ?? undefined,
+    };
+
     if (mode === 'create') {
-      createClub(data);
+      createClub(normalizedData);
       return;
     }
 
     if (club) {
-      updateClub({ clubId: club.id, data });
+      updateClub({ clubId: club.id, data: normalizedData });
+    }
+  };
+
+  const onInvalid = (errors: FieldErrors<AddClubType>) => {
+    const firstError =
+      errors.name?.message ||
+      errors.type?.message ||
+      errors.status?.message ||
+      errors.foundedYear?.message ||
+      errors.abolishedYear?.message ||
+      errors.leaderId?.message ||
+      (!Array.isArray(errors.participantIds) ? errors.participantIds?.message : undefined);
+
+    if (firstError) {
+      toast.error(String(firstError));
     }
   };
 
@@ -195,14 +218,14 @@ const ClubFormDialog = ({
     >
       {!isControlled && <DialogTrigger asChild>{trigger || defaultTrigger}</DialogTrigger>}
       <DialogContent
-        className={cn('max-w-2xl p-0')}
+        className={cn('max-w-2xl p-0 max-h-[90vh] overflow-y-auto')}
       >
         <DialogHeader className={cn('border-foreground border-b-2 px-6 py-5')}>
           <DialogTitle className={cn('font-pixel text-foreground text-[14px] leading-none')}>
             {title}
           </DialogTitle>
         </DialogHeader>
-        <form onSubmit={handleSubmit(onSubmit)} className={cn('space-y-6 px-6 py-6')}>
+        <form onSubmit={handleSubmit(onSubmit, onInvalid)} className={cn('space-y-6 px-6 py-6')}>
           <div className={cn('grid grid-cols-2 gap-4 pt-4')}>
             <div className={cn('space-y-2')}>
               <Label


### PR DESCRIPTION
## 개요 💡

동아리 데이터 수정에 대한 다이얼로그 로직이 잘못 구성되어 진행이 불가하던 것을 수정하였습니다.

## 작업내용 ⌨️

- 동아리에 혹여나 DB상에서 참가자가 비어 있는 동아리가 존재하여 이것이 반환 시 다이얼로그가 열리지 않던 문제 수정
- 수정 다이얼로그의 버튼 위치가 다이얼로그 바깥으로 밀려나 스크롤이 발생하는데 스크롤이 불가능하도록 설정되어 버튼에 실질적으로 접근하지 못하던 문제 수정
- Zod 검증 흐름이 지나치게 단순하여 운영 중인 동아리에게 폐지연도를 요구하던 것을 수정

## 스크린샷/동영상 📸

https://github.com/user-attachments/assets/d1fc6598-941a-4477-a5fa-0c10e108f2fe

