### PR TITLE
[feat] 프로젝트 상태 관리 및 어드민 UI 정리

### DIFF
--- a/apps/admin/src/entities/project/index.ts
+++ b/apps/admin/src/entities/project/index.ts
@@ -1,1 +1,2 @@
 export * from './model/schema';
+export * from './lib/utils';

--- a/apps/admin/src/entities/project/lib/utils.ts
+++ b/apps/admin/src/entities/project/lib/utils.ts
@@ -1,0 +1,12 @@
+import { ProjectStatus } from '@repo/shared/types';
+
+export const getProjectStatusLabel = (status: ProjectStatus) => {
+  switch (status) {
+    case 'ACTIVE':
+      return '운영 중';
+    case 'ENDED':
+      return '종료';
+    default:
+      return '-';
+  }
+};

--- a/apps/admin/src/entities/project/model/schema.ts
+++ b/apps/admin/src/entities/project/model/schema.ts
@@ -3,15 +3,47 @@ import { z } from 'zod';
 export const ProjectFilterSchema = z.object({
   projectName: z.string().optional(),
   clubId: z.number().optional(),
+  status: z.enum(['ACTIVE', 'ENDED']).optional(),
 });
 
 export type ProjectFilterType = z.infer<typeof ProjectFilterSchema>;
 
-export const AddProjectSchema = z.object({
-  name: z.string().min(1, { message: '프로젝트명을 입력해주세요.' }),
-  description: z.string().min(1, { message: '프로젝트 설명을 입력해주세요.' }),
-  clubId: z.number().nullable().optional(),
-  participantIds: z.array(z.number()).min(1, { message: '한 명 이상의 팀원을 선택해주세요.' }),
-});
+export const AddProjectSchema = z
+  .object({
+    name: z.string().min(1, { message: '프로젝트명을 입력해주세요.' }),
+    description: z.string().min(1, { message: '프로젝트 설명을 입력해주세요.' }),
+    startYear: z
+      .number({ message: '시작 연도를 입력해주세요.' })
+      .int()
+      .min(1900, { message: '1900년 이후의 연도를 입력해주세요.' }),
+    clubId: z.number().nullable().optional(),
+    participantIds: z.array(z.number()).min(1, { message: '한 명 이상의 팀원을 선택해주세요.' }),
+    status: z.enum(['ACTIVE', 'ENDED'], {
+      message: '운영 상태를 선택해주세요.',
+    }),
+    endYear: z.number().int().min(1900, { message: '1900년 이후의 연도를 입력해주세요.' }).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.status === 'ACTIVE') {
+      return;
+    }
+
+    if (data.endYear === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '종료 연도를 입력해주세요.',
+        path: ['endYear'],
+      });
+      return;
+    }
+
+    if (data.endYear < data.startYear) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '종료 연도는 시작 연도보다 크거나 같아야 합니다.',
+        path: ['endYear'],
+      });
+    }
+  });
 
 export type AddProjectType = z.infer<typeof AddProjectSchema>;

--- a/apps/admin/src/views/projects/model/index.ts
+++ b/apps/admin/src/views/projects/model/index.ts
@@ -2,3 +2,5 @@ export * from './useGetProjects';
 export * from './useDeleteProject';
 export * from './useCreateProject';
 export * from './useUpdateProject';
+export * from './useEndProject';
+export * from './useReactivateProject';

--- a/apps/admin/src/views/projects/model/useCreateProject.ts
+++ b/apps/admin/src/views/projects/model/useCreateProject.ts
@@ -6,8 +6,11 @@ import { AxiosError } from 'axios';
 export interface CreateProjectRequest {
   name: string;
   description: string;
+  startYear: number;
   clubId?: number | null;
   participantIds: number[];
+  status: 'ACTIVE' | 'ENDED';
+  endYear?: number;
 }
 
 export const useCreateProject = (

--- a/apps/admin/src/views/projects/model/useEndProject.ts
+++ b/apps/admin/src/views/projects/model/useEndProject.ts
@@ -1,0 +1,22 @@
+import { post, projectQueryKeys, projectUrl } from '@repo/shared/api';
+import { BaseApiResponse } from '@repo/shared/types';
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+export interface EndProjectRequest {
+  projectId: number;
+  endYear: number;
+}
+
+export const useEndProject = (
+  options?: Omit<
+    UseMutationOptions<BaseApiResponse, AxiosError, EndProjectRequest>,
+    'mutationKey' | 'mutationFn'
+  >,
+) =>
+  useMutation({
+    mutationKey: projectQueryKeys.postProjectEndById(),
+    mutationFn: ({ projectId, endYear }) =>
+      post<BaseApiResponse>(projectUrl.postProjectEndById(projectId), { endYear }),
+    ...options,
+  });

--- a/apps/admin/src/views/projects/model/useReactivateProject.ts
+++ b/apps/admin/src/views/projects/model/useReactivateProject.ts
@@ -1,0 +1,16 @@
+import { post, projectQueryKeys, projectUrl } from '@repo/shared/api';
+import { BaseApiResponse } from '@repo/shared/types';
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+export const useReactivateProject = (
+  options?: Omit<
+    UseMutationOptions<BaseApiResponse, AxiosError, number>,
+    'mutationKey' | 'mutationFn'
+  >,
+) =>
+  useMutation({
+    mutationKey: projectQueryKeys.postProjectReactivateById(),
+    mutationFn: (projectId) => post<BaseApiResponse>(projectUrl.postProjectReactivateById(projectId)),
+    ...options,
+  });

--- a/apps/admin/src/views/projects/ui/ProjectsPage/index.tsx
+++ b/apps/admin/src/views/projects/ui/ProjectsPage/index.tsx
@@ -56,7 +56,7 @@ const ProjectsPage = () => {
     (): ProjectFilterType & { page: number } => ({
       projectName: searchParams.get('projectName') || '',
       clubId: searchParams.get('clubId') ? Number(searchParams.get('clubId')) : undefined,
-      status: (searchParams.get('status') as ProjectFilterType['status']) || 'ACTIVE',
+      status: searchParams.get('status') === 'ENDED' ? 'ENDED' : 'ACTIVE',
       page: Number(searchParams.get('page')) || 0,
     }),
     [searchParams],

--- a/apps/admin/src/views/projects/ui/ProjectsPage/index.tsx
+++ b/apps/admin/src/views/projects/ui/ProjectsPage/index.tsx
@@ -56,6 +56,7 @@ const ProjectsPage = () => {
     (): ProjectFilterType & { page: number } => ({
       projectName: searchParams.get('projectName') || '',
       clubId: searchParams.get('clubId') ? Number(searchParams.get('clubId')) : undefined,
+      status: (searchParams.get('status') as ProjectFilterType['status']) || 'ACTIVE',
       page: Number(searchParams.get('page')) || 0,
     }),
     [searchParams],
@@ -66,10 +67,11 @@ const ProjectsPage = () => {
     defaultValues: {
       projectName: initialValues.projectName,
       clubId: initialValues.clubId,
+      status: initialValues.status,
     },
   });
 
-  const { register, control } = filterForm;
+  const { control } = filterForm;
 
   const filters = useWatch({
     control,
@@ -81,13 +83,16 @@ const ProjectsPage = () => {
 
   useEffect(() => {
     const hasChanged =
-      debouncedProjectName !== initialValues.projectName || filters.clubId !== initialValues.clubId;
+      debouncedProjectName !== initialValues.projectName ||
+      filters.clubId !== initialValues.clubId ||
+      filters.status !== initialValues.status;
 
     if (hasChanged) {
       updateURL(
         {
           projectName: debouncedProjectName,
           clubId: filters.clubId,
+          status: filters.status,
         },
         0,
       );
@@ -99,6 +104,7 @@ const ProjectsPage = () => {
       {
         projectName: debouncedProjectName,
         clubId: filters.clubId,
+        status: filters.status,
       },
       page,
     );
@@ -109,6 +115,7 @@ const ProjectsPage = () => {
     size: PAGE_SIZE,
     projectName: debouncedProjectName || undefined,
     clubId: filters.clubId,
+    status: filters.status,
   };
 
   const { data: projectsData, isLoading: isLoadingProjects } = useGetProjects(queryParams);
@@ -127,6 +134,11 @@ const ProjectsPage = () => {
 
   const projectForm = useForm<AddProjectType>({
     resolver: zodResolver(AddProjectSchema),
+    defaultValues: {
+      status: 'ACTIVE',
+      participantIds: [],
+      clubId: 0,
+    },
   });
 
   return (
@@ -149,7 +161,7 @@ const ProjectsPage = () => {
 
         {/* Filters */}
         <div className={cn('mb-4')}>
-          <ProjectFilter register={register} control={control} clubs={clubs} />
+          <ProjectFilter control={control} clubs={clubs} />
         </div>
 
         {/* Table */}

--- a/apps/admin/src/views/projects/ui/ProjectsPage/index.tsx
+++ b/apps/admin/src/views/projects/ui/ProjectsPage/index.tsx
@@ -97,7 +97,7 @@ const ProjectsPage = () => {
         0,
       );
     }
-  }, [debouncedProjectName, filters.clubId, initialValues, updateURL]);
+  }, [debouncedProjectName, filters.clubId, filters.status, initialValues, updateURL]);
 
   const handlePageChange = (page: number) => {
     updateURL(

--- a/apps/admin/src/widgets/api-keys/ui/ApiKeyList/index.tsx
+++ b/apps/admin/src/widgets/api-keys/ui/ApiKeyList/index.tsx
@@ -77,27 +77,26 @@ const ApiKeyList = ({ apiKeys, isLoading }: ApiKeyListProps) => {
 
   return (
     <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className={cn('w-[80px]')}>ID</TableHead>
-            <TableHead className={cn('w-[200px]')}>설명</TableHead>
-            <TableHead>API Key</TableHead>
-            <TableHead className={cn('w-[180px]')}>만료일</TableHead>
-            <TableHead className={cn('w-[100px]')}>작업</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {apiKeys.map((apiKey) => (
-            <TableRow key={apiKey.id}>
-              <TableCell className={cn('font-medium')}>{apiKey.id}</TableCell>
-              <TableCell className={cn('w-[200px] truncate')} title={apiKey.description}>
-                {apiKey.description}
-              </TableCell>
-              <TableCell className={cn('break-all font-mono text-[11px]')}>
-                {apiKey.apiKey}
-              </TableCell>
-              <TableCell>{formatDate(apiKey.expiresAt)}</TableCell>
-              <TableCell>
+      <TableHeader>
+        <TableRow>
+          <TableHead className={cn('w-[80px]')}>ID</TableHead>
+          <TableHead className={cn('w-[200px]')}>설명</TableHead>
+          <TableHead>API Key</TableHead>
+          <TableHead className={cn('w-[180px]')}>만료일</TableHead>
+          <TableHead className={cn('w-[100px]')}>작업</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {apiKeys.map((apiKey) => (
+          <TableRow key={apiKey.id}>
+            <TableCell className={cn('font-medium')}>{apiKey.id}</TableCell>
+            <TableCell className={cn('w-[200px] truncate')} title={apiKey.description}>
+              {apiKey.description}
+            </TableCell>
+            <TableCell className={cn('break-all font-mono text-[11px]')}>{apiKey.apiKey}</TableCell>
+            <TableCell>{formatDate(apiKey.expiresAt)}</TableCell>
+            <TableCell>
+              <div className={cn('flex items-center gap-2 whitespace-nowrap')}>
                 <AlertDialog onOpenChange={() => setExtendDays(30)}>
                   <AlertDialogTrigger asChild>
                     <PixelIconButton>
@@ -112,7 +111,11 @@ const ApiKeyList = ({ apiKeys, isLoading }: ApiKeyListProps) => {
                       </AlertDialogDescription>
                     </AlertDialogHeader>
                     <div className={cn('my-4 space-y-2')}>
-                      <Label className={cn('font-mono text-xs uppercase tracking-widest text-muted-foreground')}>
+                      <Label
+                        className={cn(
+                          'font-mono text-xs uppercase tracking-widest text-muted-foreground',
+                        )}
+                      >
                         연장 일수 (1~365)
                       </Label>
                       <Input
@@ -120,14 +123,18 @@ const ApiKeyList = ({ apiKeys, isLoading }: ApiKeyListProps) => {
                         min={1}
                         max={365}
                         value={extendDays}
-                        onChange={(e) => setExtendDays(Math.min(365, Math.max(1, Number(e.target.value))))}
+                        onChange={(e) =>
+                          setExtendDays(Math.min(365, Math.max(1, Number(e.target.value))))
+                        }
                         className={cn('w-32')}
                       />
                     </div>
                     <AlertDialogFooter>
                       <AlertDialogCancel>취소</AlertDialogCancel>
                       <AlertDialogAction
-                        onClick={() => updateApiKeyExpiration({ apiKeyId: apiKey.id, days: extendDays })}
+                        onClick={() =>
+                          updateApiKeyExpiration({ apiKeyId: apiKey.id, days: extendDays })
+                        }
                         className={cn('bg-black text-white hover:bg-black/50')}
                       >
                         연장
@@ -145,8 +152,8 @@ const ApiKeyList = ({ apiKeys, isLoading }: ApiKeyListProps) => {
                     <AlertDialogHeader>
                       <AlertDialogTitle>Api Key 삭제</AlertDialogTitle>
                       <AlertDialogDescription>
-                        정말로 &apos;{apiKey.description}&apos;를 삭제하시겠습니까? 이 작업은 되돌릴
-                        수 없습니다.
+                        정말로 &apos;{apiKey.description}&apos;를 삭제하시겠습니까? 이 작업은 되돌릴 수
+                        없습니다.
                       </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
@@ -160,11 +167,12 @@ const ApiKeyList = ({ apiKeys, isLoading }: ApiKeyListProps) => {
                     </AlertDialogFooter>
                   </AlertDialogContent>
                 </AlertDialog>
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+              </div>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
   );
 };
 

--- a/apps/admin/src/widgets/projects/ui/ProjectFilter/index.tsx
+++ b/apps/admin/src/widgets/projects/ui/ProjectFilter/index.tsx
@@ -54,15 +54,11 @@ const ProjectFilter = ({ control, clubs }: ProjectFilterProps) => {
             control={control}
             name="status"
             render={({ field }) => (
-              <Select
-                value={field.value ?? 'ACTIVE'}
-                onValueChange={(value) => field.onChange(value === 'all' ? undefined : value)}
-              >
+              <Select value={field.value ?? 'ACTIVE'} onValueChange={field.onChange}>
                 <SelectTrigger className={cn('border-foreground w-28 rounded-none')}>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="all">전체</SelectItem>
                   <SelectItem value="ACTIVE">운영 중</SelectItem>
                   <SelectItem value="ENDED">종료</SelectItem>
                 </SelectContent>

--- a/apps/admin/src/widgets/projects/ui/ProjectFilter/index.tsx
+++ b/apps/admin/src/widgets/projects/ui/ProjectFilter/index.tsx
@@ -10,35 +10,72 @@ import {
 } from '@repo/shared/ui';
 import { cn } from '@repo/shared/utils';
 import { Search } from 'lucide-react';
-import { Control, Controller, UseFormRegister } from 'react-hook-form';
+import { Control, Controller } from 'react-hook-form';
 
 import { ProjectFilterType } from '@/entities/project';
 
 interface ProjectFilterProps {
-  register: UseFormRegister<ProjectFilterType>;
   control: Control<ProjectFilterType>;
   clubs: Club[];
 }
 
-const ProjectFilter = ({ register, control, clubs }: ProjectFilterProps) => {
+const ProjectFilter = ({ control, clubs }: ProjectFilterProps) => {
   return (
-    <div className={cn('mt-4 flex flex-col gap-4')}>
-      <div className={cn('flex items-center gap-2')}>
-        <div className={cn('relative flex-1')}>
-          <Search
-            className={cn('text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2')}
-          />
-          <Input
-            placeholder="프로젝트 이름으로 검색"
-            className={cn('pl-9')}
-            {...register('projectName')}
-          />
-        </div>
+    <div className={cn('mt-4 flex flex-col justify-center gap-4')}>
+      <div className={cn('relative flex-1')}>
+        <Search
+          className={cn('text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2')}
+        />
+        <Controller
+          control={control}
+          name="projectName"
+          render={({ field }) => (
+            <Input
+              {...field}
+              placeholder="프로젝트 이름으로 검색"
+              className={cn('border-foreground rounded-none pl-9 font-mono')}
+              onChange={(e) => {
+                field.onChange(e.target.value || 'all');
+              }}
+              value={field.value === 'all' ? '' : field.value}
+            />
+          )}
+        />
       </div>
 
-      <div className={cn('flex flex-wrap items-center gap-4')}>
+      <div className={cn('flex items-center gap-4')}>
         <div className={cn('flex items-center gap-2')}>
-          <Label className={cn('shrink-0 text-sm')}>동아리:</Label>
+          <Label
+            className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
+          >
+            상태:
+          </Label>
+          <Controller
+            control={control}
+            name="status"
+            render={({ field }) => (
+              <Select
+                value={field.value ?? 'ACTIVE'}
+                onValueChange={(value) => field.onChange(value === 'all' ? undefined : value)}
+              >
+                <SelectTrigger className={cn('border-foreground w-28 rounded-none')}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">전체</SelectItem>
+                  <SelectItem value="ACTIVE">운영 중</SelectItem>
+                  <SelectItem value="ENDED">종료</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </div>
+        <div className={cn('flex items-center gap-2')}>
+          <Label
+            className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
+          >
+            동아리:
+          </Label>
           <Controller
             control={control}
             name="clubId"
@@ -47,8 +84,8 @@ const ProjectFilter = ({ register, control, clubs }: ProjectFilterProps) => {
                 value={field.value ? String(field.value) : 'all'}
                 onValueChange={(val) => field.onChange(val === 'all' ? undefined : Number(val))}
               >
-                <SelectTrigger className={cn('w-40')}>
-                  <SelectValue placeholder="전체" />
+                <SelectTrigger className={cn('border-foreground w-40 rounded-none')}>
+                  <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="all">전체</SelectItem>

--- a/apps/admin/src/widgets/projects/ui/ProjectFilter/index.tsx
+++ b/apps/admin/src/widgets/projects/ui/ProjectFilter/index.tsx
@@ -34,10 +34,8 @@ const ProjectFilter = ({ control, clubs }: ProjectFilterProps) => {
               {...field}
               placeholder="프로젝트 이름으로 검색"
               className={cn('border-foreground rounded-none pl-9 font-mono')}
-              onChange={(e) => {
-                field.onChange(e.target.value || 'all');
-              }}
-              value={field.value === 'all' ? '' : field.value}
+              onChange={field.onChange}
+              value={field.value ?? ''}
             />
           )}
         />

--- a/apps/admin/src/widgets/projects/ui/ProjectFormDialog/index.tsx
+++ b/apps/admin/src/widgets/projects/ui/ProjectFormDialog/index.tsx
@@ -30,11 +30,16 @@ import {
 import { cn } from '@repo/shared/utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { ChevronDown, Pencil, Plus, X } from 'lucide-react';
-import { Controller, SubmitHandler, UseFormReturn } from 'react-hook-form';
+import { Controller, FieldErrors, SubmitHandler, UseFormReturn } from 'react-hook-form';
 import { toast } from 'sonner';
 
 import { AddProjectType } from '@/entities/project';
-import { useCreateProject, useUpdateProject } from '@/views/projects/model';
+import {
+  useCreateProject,
+  useEndProject,
+  useReactivateProject,
+  useUpdateProject,
+} from '@/views/projects/model';
 
 interface ProjectFormDialogProps {
   mode: 'create' | 'edit';
@@ -70,9 +75,12 @@ const ProjectFormDialog = ({
     register,
     reset,
     control,
+    watch,
+    setValue,
     formState: { errors },
   } = form;
 
+  const currentStatus = watch('status');
   const [searchTerm, setSearchTerm] = useState('');
   const [memberPopoverOpen, setMemberPopoverOpen] = useState(false);
   const memberSearchRef = useRef<HTMLInputElement>(null);
@@ -86,27 +94,10 @@ const ProjectFormDialog = ({
     );
   }, [students, searchTerm]);
 
-  const { mutate: createProject } = useCreateProject({
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['projects'] });
-      toast.success('프로젝트가 등록되었습니다.');
-      setOpen(false);
-    },
-    onError: () => {
-      toast.error('프로젝트 등록에 실패했습니다.');
-    },
-  });
-
-  const { mutate: updateProject } = useUpdateProject({
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['projects'] });
-      toast.success('프로젝트 데이터가 수정되었습니다.');
-      setOpen(false);
-    },
-    onError: () => {
-      toast.error('프로젝트 데이터 수정에 실패했습니다.');
-    },
-  });
+  const { mutateAsync: createProject, isPending: isCreating } = useCreateProject();
+  const { mutateAsync: updateProject, isPending: isUpdating } = useUpdateProject();
+  const { mutateAsync: endProject, isPending: isEnding } = useEndProject();
+  const { mutateAsync: reactivateProject, isPending: isReactivating } = useReactivateProject();
 
   useEffect(() => {
     if (open) {
@@ -114,19 +105,31 @@ const ProjectFormDialog = ({
         reset({
           name: project.name,
           description: project.description,
+          startYear: project.startYear,
           clubId: project.club?.id || 0,
           participantIds: project.participants.map((p) => p.id),
+          status: project.status,
+          endYear: project.endYear ?? undefined,
         });
       } else if (mode === 'create') {
         reset({
           name: '',
           description: '',
+          startYear: undefined,
           clubId: 0,
           participantIds: [],
+          status: 'ACTIVE',
+          endYear: undefined,
         });
       }
     }
   }, [mode, project, open, reset]);
+
+  useEffect(() => {
+    if (currentStatus === 'ACTIVE') {
+      setValue('endYear', undefined);
+    }
+  }, [currentStatus, setValue]);
 
   useEffect(() => {
     if (!open) {
@@ -134,19 +137,48 @@ const ProjectFormDialog = ({
     }
   }, [open]);
 
-  const onSubmit: SubmitHandler<AddProjectType> = (data) => {
+  const onSubmit: SubmitHandler<AddProjectType> = async (data) => {
     const formattedData = {
       ...data,
       clubId: data.clubId === 0 ? null : data.clubId,
+      endYear: data.status === 'ENDED' ? data.endYear : undefined,
     };
 
-    if (mode === 'create') {
-      createProject(formattedData);
-    } else if (mode === 'edit' && project) {
-      updateProject({ projectId: project.id, data: formattedData });
+    try {
+      if (mode === 'create') {
+        await createProject(formattedData);
+        toast.success('프로젝트가 등록되었습니다.');
+      } else if (mode === 'edit' && project) {
+        await updateProject({ projectId: project.id, data: formattedData });
+
+        if (formattedData.status === 'ENDED' && formattedData.endYear !== undefined) {
+          await endProject({ projectId: project.id, endYear: formattedData.endYear });
+        } else if (project.status === 'ENDED') {
+          await reactivateProject(project.id);
+        }
+
+        toast.success('프로젝트 데이터가 수정되었습니다.');
+      }
+
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      setOpen(false);
+      reset();
+    } catch {
+      toast.error(mode === 'create' ? '프로젝트 등록에 실패했습니다.' : '프로젝트 데이터 수정에 실패했습니다.');
     }
   };
 
+  const onInvalid = (errors: FieldErrors<AddProjectType>) => {
+    const firstError = Object.values(errors)
+      .flat()
+      .find((error) => error?.message);
+
+    if (firstError?.message) {
+      toast.error(String(firstError.message));
+    }
+  };
+
+  const isPending = isCreating || isUpdating || isEnding || isReactivating;
   const title = mode === 'create' ? '프로젝트 추가' : '프로젝트 데이터 수정';
   const submitText = mode === 'create' ? '추가' : '수정';
 
@@ -179,7 +211,7 @@ const ProjectFormDialog = ({
             {title}
           </DialogTitle>
         </DialogHeader>
-        <form onSubmit={handleSubmit(onSubmit)} className={cn('space-y-6 px-6 py-6')}>
+        <form onSubmit={handleSubmit(onSubmit, onInvalid)} className={cn('space-y-6 px-6 py-6')}>
           <div className={cn('grid grid-cols-2 gap-4 pt-4')}>
             <div className={cn('space-y-2')}>
               <Label
@@ -195,6 +227,48 @@ const ProjectFormDialog = ({
                 {...register('name')}
               />
               <FormErrorMessage error={errors.name} />
+            </div>
+            <div className={cn('space-y-2')}>
+              <Label
+                htmlFor="status"
+                className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
+              >
+                운영 상태
+              </Label>
+              <Controller
+                control={control}
+                name="status"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className={cn('border-foreground rounded-none font-mono')}>
+                      <SelectValue placeholder="상태 선택" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="ACTIVE">운영 중</SelectItem>
+                      <SelectItem value="ENDED">종료</SelectItem>
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+              <FormErrorMessage error={errors.status} />
+            </div>
+            <div className={cn('space-y-2')}>
+              <Label
+                htmlFor="startYear"
+                className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
+              >
+                시작 연도
+              </Label>
+              <Input
+                id="startYear"
+                type="number"
+                placeholder="시작 연도 입력"
+                className={cn('border-foreground rounded-none font-mono')}
+                {...register('startYear', {
+                  setValueAs: (value) => (value === '' ? undefined : Number(value)),
+                })}
+              />
+              <FormErrorMessage error={errors.startYear} />
             </div>
             <div className={cn('space-y-2')}>
               <Label
@@ -231,6 +305,26 @@ const ProjectFormDialog = ({
               />
               <FormErrorMessage error={errors.clubId} />
             </div>
+            {currentStatus === 'ENDED' && (
+              <div className={cn('space-y-2')}>
+                <Label
+                  htmlFor="endYear"
+                  className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
+                >
+                  종료 연도
+                </Label>
+                <Input
+                  id="endYear"
+                  type="number"
+                  placeholder="종료 연도 입력"
+                  className={cn('border-foreground rounded-none font-mono')}
+                  {...register('endYear', {
+                    setValueAs: (value) => (value === '' ? undefined : Number(value)),
+                  })}
+                />
+                <FormErrorMessage error={errors.endYear} />
+              </div>
+            )}
             <div className={cn('col-span-2 space-y-2')}>
               <Label
                 htmlFor="description"
@@ -339,100 +433,102 @@ const ProjectFormDialog = ({
             className={cn('bg-background')}
           >
             <div className={cn('flex flex-col gap-5 p-4')}>
-            <Controller
-              control={control}
-              name="participantIds"
-              render={({ field }) => {
-                const selectedIds = Array.isArray(field.value) ? field.value : [];
-                const selectedStudents = students?.filter((s) => selectedIds.includes(s.id)) || [];
+              <Controller
+                control={control}
+                name="participantIds"
+                render={({ field }) => {
+                  const selectedIds = Array.isArray(field.value) ? field.value : [];
+                  const selectedStudents = students?.filter((s) => selectedIds.includes(s.id)) || [];
 
-                const grades = [1, 2, 3];
+                  const grades = [1, 2, 3];
 
-                return (
-                  <div className={cn('grid grid-cols-1 gap-4 md:grid-cols-3')}>
-                    {grades.map((grade) => (
-                      <div
-                        key={grade}
-                        className={cn(
-                          'border-foreground bg-background flex min-h-[240px] flex-col border',
-                        )}
-                      >
+                  return (
+                    <div className={cn('grid grid-cols-1 gap-4 md:grid-cols-3')}>
+                      {grades.map((grade) => (
                         <div
+                          key={grade}
                           className={cn(
-                            'border-foreground flex items-center justify-between border-b px-3 py-2',
+                            'border-foreground bg-background flex min-h-[240px] flex-col border',
                           )}
                         >
-                          <span className={cn('font-pixel text-foreground text-[11px]')}>
-                            GRADE {grade}
-                          </span>
-                          <span className={cn('text-muted-foreground font-mono text-[11px]')}>
-                            {selectedStudents.filter((s) => s.grade === grade).length}
-                          </span>
-                        </div>
-                        <div
-                          className={cn(
-                            '[&::-webkit-scrollbar-thumb]:bg-foreground/30 max-h-75 flex flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden p-3 [&::-webkit-scrollbar-thumb]:rounded-none [&::-webkit-scrollbar]:w-1',
-                          )}
-                        >
-                          {selectedStudents
-                            .filter((s) => s.grade === grade)
-                            .map((student) => (
-                              <button
-                                key={student.id}
-                                type="button"
-                                className={cn(
-                                  'border-foreground hover:bg-foreground hover:text-background group flex w-full items-center justify-between gap-3 border px-3 py-2 text-left transition-colors',
-                                )}
-                                onClick={() =>
-                                  field.onChange(
-                                    field.value.filter((id: number) => id !== student.id),
-                                  )
-                                }
-                              >
-                                <span className={cn('min-w-0 flex-1')}>
-                                  <span
-                                    className={cn(
-                                      'text-muted-foreground group-hover:text-background/80 block font-mono text-[11px] uppercase transition-colors',
-                                    )}
-                                  >
-                                    {student.studentNumber}
-                                  </span>
-                                  <span
-                                    className={cn(
-                                      'text-foreground group-hover:text-background block truncate font-mono text-xs transition-colors',
-                                    )}
-                                  >
-                                    {student.name}
-                                  </span>
-                                </span>
-                                <X
+                          <div
+                            className={cn(
+                              'border-foreground flex items-center justify-between border-b px-3 py-2',
+                            )}
+                          >
+                            <span className={cn('font-pixel text-foreground text-[11px]')}>
+                              GRADE {grade}
+                            </span>
+                            <span className={cn('text-muted-foreground font-mono text-[11px]')}>
+                              {selectedStudents.filter((s) => s.grade === grade).length}
+                            </span>
+                          </div>
+                          <div
+                            className={cn(
+                              '[&::-webkit-scrollbar-thumb]:bg-foreground/30 max-h-75 flex flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden p-3 [&::-webkit-scrollbar-thumb]:rounded-none [&::-webkit-scrollbar]:w-1',
+                            )}
+                          >
+                            {selectedStudents
+                              .filter((s) => s.grade === grade)
+                              .map((student) => (
+                                <button
+                                  key={student.id}
+                                  type="button"
                                   className={cn(
-                                    'group-hover:text-background h-4 w-4 shrink-0 transition-colors',
+                                    'border-foreground hover:bg-foreground hover:text-background group flex w-full items-center justify-between gap-3 border px-3 py-2 text-left transition-colors',
                                   )}
-                                />
-                              </button>
-                            ))}
-                          {selectedStudents.filter((s) => s.grade === grade).length === 0 && (
-                            <div
-                              className={cn(
-                                'border-foreground/30 bg-muted/10 text-muted-foreground border border-dashed px-3 py-6 text-center font-mono text-[11px] uppercase tracking-[0.18em]',
-                              )}
-                            >
-                              등록된 팀원 없음
-                            </div>
-                          )}
+                                  onClick={() =>
+                                    field.onChange(
+                                      field.value.filter((id: number) => id !== student.id),
+                                    )
+                                  }
+                                >
+                                  <span className={cn('min-w-0 flex-1')}>
+                                    <span
+                                      className={cn(
+                                        'text-muted-foreground group-hover:text-background/80 block font-mono text-[11px] uppercase transition-colors',
+                                      )}
+                                    >
+                                      {student.studentNumber}
+                                    </span>
+                                    <span
+                                      className={cn(
+                                        'text-foreground group-hover:text-background block truncate font-mono text-xs transition-colors',
+                                      )}
+                                    >
+                                      {student.name}
+                                    </span>
+                                  </span>
+                                  <X
+                                    className={cn(
+                                      'group-hover:text-background h-4 w-4 shrink-0 transition-colors',
+                                    )}
+                                  />
+                                </button>
+                              ))}
+                            {selectedStudents.filter((s) => s.grade === grade).length === 0 && (
+                              <div
+                                className={cn(
+                                  'border-foreground/30 bg-muted/10 text-muted-foreground border border-dashed px-3 py-6 text-center font-mono text-[11px] uppercase tracking-[0.18em]',
+                                )}
+                              >
+                                등록된 팀원 없음
+                              </div>
+                            )}
+                          </div>
                         </div>
-                      </div>
-                    ))}
-                  </div>
-                );
-              }}
-            />
+                      ))}
+                    </div>
+                  );
+                }}
+              />
             </div>
           </SectionCard>
 
           <div className={cn('flex justify-end pt-2')}>
-            <Button type="submit">{submitText}</Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? `${submitText} 중...` : submitText}
+            </Button>
           </div>
         </form>
       </DialogContent>

--- a/apps/admin/src/widgets/projects/ui/ProjectFormDialog/index.tsx
+++ b/apps/admin/src/widgets/projects/ui/ProjectFormDialog/index.tsx
@@ -151,9 +151,16 @@ const ProjectFormDialog = ({
       } else if (mode === 'edit' && project) {
         await updateProject({ projectId: project.id, data: formattedData });
 
-        if (formattedData.status === 'ENDED' && formattedData.endYear !== undefined) {
+        const isStatusChanged = project.status !== formattedData.status;
+        const isEndYearChanged = project.endYear !== (formattedData.endYear ?? null);
+
+        if (
+          formattedData.status === 'ENDED' &&
+          formattedData.endYear !== undefined &&
+          (isStatusChanged || isEndYearChanged)
+        ) {
           await endProject({ projectId: project.id, endYear: formattedData.endYear });
-        } else if (project.status === 'ENDED') {
+        } else if (isStatusChanged && project.status === 'ENDED') {
           await reactivateProject(project.id);
         }
 

--- a/apps/admin/src/widgets/projects/ui/ProjectFormDialog/index.tsx
+++ b/apps/admin/src/widgets/projects/ui/ProjectFormDialog/index.tsx
@@ -252,79 +252,88 @@ const ProjectFormDialog = ({
               />
               <FormErrorMessage error={errors.status} />
             </div>
-            <div className={cn('space-y-2')}>
-              <Label
-                htmlFor="startYear"
-                className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
-              >
-                시작 연도
-              </Label>
-              <Input
-                id="startYear"
-                type="number"
-                placeholder="시작 연도 입력"
-                className={cn('border-foreground rounded-none font-mono')}
-                {...register('startYear', {
-                  setValueAs: (value) => (value === '' ? undefined : Number(value)),
-                })}
-              />
-              <FormErrorMessage error={errors.startYear} />
-            </div>
-            <div className={cn('space-y-2')}>
-              <Label
-                htmlFor="clubId"
-                className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
-              >
-                동아리
-              </Label>
-              <Controller
-                control={control}
-                name="clubId"
-                render={({ field }) => (
-                  <Select
-                    value={field.value ? String(field.value) : 'none'}
-                    onValueChange={(val) => field.onChange(val === 'none' ? 0 : Number(val))}
-                  >
-                    <SelectTrigger
-                      className={cn(
-                        'border-foreground rounded-none font-mono',
-                      )}
-                    >
-                      <SelectValue placeholder="동아리 선택" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="none">선택 안 함</SelectItem>
-                      {clubs.map((club) => (
-                        <SelectItem key={club.id} value={String(club.id)}>
-                          {club.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-              />
-              <FormErrorMessage error={errors.clubId} />
-            </div>
-            {currentStatus === 'ENDED' && (
+            <div
+              className={cn(
+                'col-span-2 grid gap-4',
+                currentStatus === 'ENDED' ? 'md:grid-cols-3' : 'md:grid-cols-2',
+              )}
+            >
               <div className={cn('space-y-2')}>
                 <Label
-                  htmlFor="endYear"
-                  className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
+                  htmlFor="startYear"
+                  className={cn(
+                    'text-muted-foreground font-mono text-xs uppercase tracking-widest',
+                  )}
                 >
-                  종료 연도
+                  시작 연도
                 </Label>
                 <Input
-                  id="endYear"
+                  id="startYear"
                   type="number"
-                  placeholder="종료 연도 입력"
+                  placeholder="시작 연도 입력"
                   className={cn('border-foreground rounded-none font-mono')}
-                  {...register('endYear', {
+                  {...register('startYear', {
                     setValueAs: (value) => (value === '' ? undefined : Number(value)),
                   })}
                 />
-                <FormErrorMessage error={errors.endYear} />
+                <FormErrorMessage error={errors.startYear} />
               </div>
-            )}
+              {currentStatus === 'ENDED' && (
+                <div className={cn('space-y-2')}>
+                  <Label
+                    htmlFor="endYear"
+                    className={cn(
+                      'text-muted-foreground font-mono text-xs uppercase tracking-widest',
+                    )}
+                  >
+                    종료 연도
+                  </Label>
+                  <Input
+                    id="endYear"
+                    type="number"
+                    placeholder="종료 연도 입력"
+                    className={cn('border-foreground rounded-none font-mono')}
+                    {...register('endYear', {
+                      setValueAs: (value) => (value === '' ? undefined : Number(value)),
+                    })}
+                  />
+                  <FormErrorMessage error={errors.endYear} />
+                </div>
+              )}
+              <div className={cn('space-y-2')}>
+                <Label
+                  htmlFor="clubId"
+                  className={cn(
+                    'text-muted-foreground font-mono text-xs uppercase tracking-widest',
+                  )}
+                >
+                  동아리
+                </Label>
+                <Controller
+                  control={control}
+                  name="clubId"
+                  render={({ field }) => (
+                    <Select
+                      value={field.value ? String(field.value) : 'none'}
+                      onValueChange={(val) => field.onChange(val === 'none' ? 0 : Number(val))}
+                    >
+                      <SelectTrigger className={cn('border-foreground rounded-none font-mono')}>
+                        <SelectValue placeholder="동아리 선택" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="none">선택 안 함</SelectItem>
+                        {clubs.map((club) => (
+                          <SelectItem key={club.id} value={String(club.id)}>
+                            {club.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
+                <FormErrorMessage error={errors.clubId} />
+              </div>
+            </div>
             <div className={cn('col-span-2 space-y-2')}>
               <Label
                 htmlFor="description"

--- a/apps/admin/src/widgets/projects/ui/ProjectList/index.tsx
+++ b/apps/admin/src/widgets/projects/ui/ProjectList/index.tsx
@@ -21,6 +21,8 @@ import {
 import { cn } from '@repo/shared/utils';
 import { Pencil, Trash2 } from 'lucide-react';
 
+import { getProjectStatusLabel } from '@/entities/project';
+
 interface ProjectListProps {
   projects: Project[];
   isLoading?: boolean;
@@ -31,81 +33,107 @@ interface ProjectListProps {
 const ProjectList = ({ projects, isLoading, onEdit, onDelete }: ProjectListProps) => {
   return (
     <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>이름</TableHead>
-            <TableHead>설명</TableHead>
-            <TableHead>동아리</TableHead>
-            <TableHead className={cn('w-24')}></TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {isLoading ? (
-            Array.from({ length: 10 }).map((_, index) => (
-              <TableRow key={index}>
-                <TableCell>
-                  <Skeleton className={cn('h-4 w-32')} />
-                </TableCell>
-                <TableCell>
-                  <Skeleton className={cn('h-4 w-48')} />
-                </TableCell>
-                <TableCell>
-                  <Skeleton className={cn('h-4 w-24')} />
-                </TableCell>
-                <TableCell>
-                  <Skeleton className={cn('h-8 w-8')} />
-                </TableCell>
-              </TableRow>
-            ))
-          ) : projects.length > 0 ? (
-            projects.map((project) => (
-              <TableRow key={project.id}>
-                <TableCell className={cn('font-medium')}>{project.name}</TableCell>
-                <TableCell className={cn('max-w-xs truncate')}>{project.description}</TableCell>
-                <TableCell>{project.club?.name || '무소속'}</TableCell>
-                <TableCell>
-                  <div className={cn('flex items-center gap-2')}>
-                    <PixelIconButton onClick={() => onEdit?.(project)}>
-                      <Pencil className={cn('h-3.5 w-3.5')} />
-                    </PixelIconButton>
-                    <AlertDialog>
-                      <AlertDialogTrigger asChild>
-                        <PixelIconButton variant="destructive">
-                          <Trash2 className={cn('h-3.5 w-3.5')} />
-                        </PixelIconButton>
-                      </AlertDialogTrigger>
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>프로젝트 삭제</AlertDialogTitle>
-                          <AlertDialogDescription>
-                            정말로 &apos;{project.name}&apos; 프로젝트를 삭제하시겠습니까? 이 작업은
-                            되돌릴 수 없습니다.
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel>취소</AlertDialogCancel>
-                          <AlertDialogAction
-                            onClick={() => onDelete?.(project.id)}
-                            className={cn('bg-destructive hover:bg-destructive/90 text-white')}
-                          >
-                            삭제
-                          </AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    </AlertDialog>
-                  </div>
-                </TableCell>
-              </TableRow>
-            ))
-          ) : (
-            <TableRow>
-              <TableCell colSpan={4} className={cn('text-muted-foreground h-32 text-center')}>
-                프로젝트 데이터가 없습니다.
+      <TableHeader>
+        <TableRow>
+          <TableHead>이름</TableHead>
+          <TableHead>상태</TableHead>
+          <TableHead>시작 연도</TableHead>
+          <TableHead>종료 연도</TableHead>
+          <TableHead>설명</TableHead>
+          <TableHead>동아리</TableHead>
+          <TableHead className={cn('w-24')}>작업</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {isLoading ? (
+          Array.from({ length: 10 }).map((_, index) => (
+            <TableRow key={index}>
+              <TableCell>
+                <Skeleton className={cn('h-4 w-32')} />
+              </TableCell>
+              <TableCell>
+                <Skeleton className={cn('h-5 w-14')} />
+              </TableCell>
+              <TableCell>
+                <Skeleton className={cn('h-4 w-12')} />
+              </TableCell>
+              <TableCell>
+                <Skeleton className={cn('h-4 w-12')} />
+              </TableCell>
+              <TableCell>
+                <Skeleton className={cn('h-4 w-48')} />
+              </TableCell>
+              <TableCell>
+                <Skeleton className={cn('h-4 w-24')} />
+              </TableCell>
+              <TableCell>
+                <Skeleton className={cn('h-8 w-8')} />
               </TableCell>
             </TableRow>
-          )}
-        </TableBody>
-      </Table>
+          ))
+        ) : projects.length > 0 ? (
+          projects.map((project) => (
+            <TableRow key={project.id}>
+              <TableCell className={cn('font-medium')}>{project.name}</TableCell>
+              <TableCell>
+                <span
+                  className={cn(
+                    'px-1.5 py-0.5 font-mono text-xs uppercase',
+                    project.status === 'ACTIVE'
+                      ? 'bg-foreground text-background'
+                      : 'border-foreground/25 text-muted-foreground border',
+                  )}
+                >
+                  {getProjectStatusLabel(project.status)}
+                </span>
+              </TableCell>
+              <TableCell className={cn('font-mono text-xs')}>{project.startYear}</TableCell>
+              <TableCell className={cn('font-mono text-xs')}>{project.endYear ?? '-'}</TableCell>
+              <TableCell className={cn('max-w-xs truncate')}>{project.description}</TableCell>
+              <TableCell>{project.club?.name || '무소속'}</TableCell>
+              <TableCell>
+                <div className={cn('flex items-center gap-2')}>
+                  <PixelIconButton onClick={() => onEdit?.(project)}>
+                    <Pencil className={cn('h-3.5 w-3.5')} />
+                  </PixelIconButton>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <PixelIconButton variant="destructive">
+                        <Trash2 className={cn('h-3.5 w-3.5')} />
+                      </PixelIconButton>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>프로젝트 삭제</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          정말로 &apos;{project.name}&apos; 프로젝트를 삭제하시겠습니까? 이 작업은
+                          되돌릴 수 없습니다.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>취소</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={() => onDelete?.(project.id)}
+                          className={cn('bg-destructive hover:bg-destructive/90 text-white')}
+                        >
+                          삭제
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </div>
+              </TableCell>
+            </TableRow>
+          ))
+        ) : (
+          <TableRow>
+            <TableCell colSpan={7} className={cn('text-muted-foreground h-32 text-center')}>
+              프로젝트 데이터가 없습니다.
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
   );
 };
 

--- a/apps/admin/src/widgets/students/ui/StudentList/index.tsx
+++ b/apps/admin/src/widgets/students/ui/StudentList/index.tsx
@@ -23,83 +23,85 @@ interface StudentListProps {
 const StudentList = ({ students, isLoading, onEdit }: StudentListProps) => {
   return (
     <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>이름</TableHead>
-            <TableHead>성별</TableHead>
-            <TableHead>이메일</TableHead>
-            <TableHead>학번</TableHead>
-            <TableHead>학과</TableHead>
-            <TableHead>구분</TableHead>
-            <TableHead>기숙사 호실</TableHead>
-            <TableHead>전공동아리</TableHead>
-            <TableHead>자율동아리</TableHead>
-            <TableHead className={cn('w-20')}>수정</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {isLoading
-            ? Array.from({ length: 10 }).map((_, index) => (
-                <TableRow key={index}>
-                  <TableCell>
-                    <Skeleton className={cn('h-4 w-16')} />
-                  </TableCell>
-                  <TableCell>
-                    <Skeleton className={cn('h-4 w-8')} />
-                  </TableCell>
-                  <TableCell>
-                    <Skeleton className={cn('h-4 w-32')} />
-                  </TableCell>
-                  <TableCell>
-                    <Skeleton className={cn('h-4 w-16')} />
-                  </TableCell>
-                  <TableCell>
-                    <Skeleton className={cn('h-4 w-24')} />
-                  </TableCell>
-                  <TableCell>
-                    <Skeleton className={cn('h-5 w-16')} />
-                  </TableCell>
-                  <TableCell>
-                    <Skeleton className={cn('h-4 w-12')} />
-                  </TableCell>
-                  <TableCell>
-                    <Skeleton className={cn('h-4 w-20')} />
-                  </TableCell>
-                  <TableCell>
-                    <Skeleton className={cn('h-4 w-20')} />
-                  </TableCell>
-                  <TableCell>
-                    <Skeleton className={cn('h-8 w-8')} />
-                  </TableCell>
-                </TableRow>
-              ))
-            : students?.map((student) => (
-                <TableRow key={student.id}>
-                  <TableCell>{student.name}</TableCell>
-                  <TableCell>{getSexLabel(student.sex)}</TableCell>
-                  <TableCell>{student.email}</TableCell>
-                  <TableCell>{student.studentNumber}</TableCell>
-                  <TableCell>{getMajorLabel(student.major)}</TableCell>
-                  <TableCell>
-                    <span className={cn('border px-1.5 py-0.5 text-xs font-mono uppercase', getRoleBadgeStyle(student.role))}>
-                      {getRoleLabel(student.role)}
-                    </span>
-                  </TableCell>
-                  <TableCell>
-                    {student.dormitoryRoom ? `${student.dormitoryRoom}호` : '없음'}
-                  </TableCell>
-                  <TableCell>{student.majorClub?.name ?? '없음'}</TableCell>
-                  <TableCell>{student.autonomousClub?.name ?? '없음'}</TableCell>
-
-                  <TableCell>
-                    <PixelIconButton onClick={() => onEdit?.(student)}>
-                      <Pencil className={cn('h-3.5 w-3.5')} />
-                    </PixelIconButton>
-                  </TableCell>
-                </TableRow>
-              ))}
-        </TableBody>
-      </Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>이름</TableHead>
+          <TableHead>성별</TableHead>
+          <TableHead>이메일</TableHead>
+          <TableHead>학번</TableHead>
+          <TableHead>학과</TableHead>
+          <TableHead>구분</TableHead>
+          <TableHead>기숙사 호실</TableHead>
+          <TableHead>전공동아리</TableHead>
+          <TableHead>자율동아리</TableHead>
+          <TableHead className={cn('w-20')}>작업</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {isLoading
+          ? Array.from({ length: 10 }).map((_, index) => (
+              <TableRow key={index}>
+                <TableCell>
+                  <Skeleton className={cn('h-4 w-16')} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className={cn('h-4 w-8')} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className={cn('h-4 w-32')} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className={cn('h-4 w-16')} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className={cn('h-4 w-24')} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className={cn('h-5 w-16')} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className={cn('h-4 w-12')} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className={cn('h-4 w-20')} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className={cn('h-4 w-20')} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className={cn('h-8 w-8')} />
+                </TableCell>
+              </TableRow>
+            ))
+          : students?.map((student) => (
+              <TableRow key={student.id}>
+                <TableCell>{student.name}</TableCell>
+                <TableCell>{getSexLabel(student.sex)}</TableCell>
+                <TableCell>{student.email}</TableCell>
+                <TableCell>{student.studentNumber}</TableCell>
+                <TableCell>{getMajorLabel(student.major)}</TableCell>
+                <TableCell>
+                  <span
+                    className={cn(
+                      'border px-1.5 py-0.5 text-xs font-mono uppercase',
+                      getRoleBadgeStyle(student.role),
+                    )}
+                  >
+                    {getRoleLabel(student.role)}
+                  </span>
+                </TableCell>
+                <TableCell>{student.dormitoryRoom ? `${student.dormitoryRoom}호` : '없음'}</TableCell>
+                <TableCell>{student.majorClub?.name ?? '없음'}</TableCell>
+                <TableCell>{student.autonomousClub?.name ?? '없음'}</TableCell>
+                <TableCell>
+                  <PixelIconButton onClick={() => onEdit?.(student)}>
+                    <Pencil className={cn('h-3.5 w-3.5')} />
+                  </PixelIconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+      </TableBody>
+    </Table>
   );
 };
 

--- a/packages/shared/src/api/apiUrls.ts
+++ b/packages/shared/src/api/apiUrls.ts
@@ -84,11 +84,14 @@ export const authUrl = {
 export const projectUrl = {
   putProjectById: (projectId: number) => `/v1/projects/${projectId}`,
   deleteProjectById: (projectId: number) => `/v1/projects/${projectId}`,
+  postProjectEndById: (projectId: number) => `/v1/projects/${projectId}/end`,
+  postProjectReactivateById: (projectId: number) => `/v1/projects/${projectId}/reactivate`,
   getProjects: (params: {
     page?: number;
     size?: number;
     projectName?: string;
     clubId?: number;
+    status?: 'ACTIVE' | 'ENDED';
   }) => {
     const urlParams = new URLSearchParams();
 
@@ -96,6 +99,7 @@ export const projectUrl = {
     if (params.size !== undefined) urlParams.append('size', params.size.toString());
     if (params.projectName) urlParams.append('projectName', params.projectName);
     if (params.clubId !== undefined) urlParams.append('clubId', params.clubId.toString());
+    if (params.status !== undefined) urlParams.append('status', params.status);
 
     const queryString = urlParams.toString();
     return queryString ? `/v1/projects?${queryString}` : '/v1/projects';

--- a/packages/shared/src/api/queryKeys.ts
+++ b/packages/shared/src/api/queryKeys.ts
@@ -67,7 +67,15 @@ export const authQueryKeys = {
 export const projectQueryKeys = {
   putProjectById: () => ['projects', 'update'] as const,
   deleteProjectById: () => ['projects', 'delete'] as const,
-  getProjects: (params: { page?: number; size?: number; projectName?: string; clubId?: number }) =>
+  postProjectEndById: () => ['projects', 'end'] as const,
+  postProjectReactivateById: () => ['projects', 'reactivate'] as const,
+  getProjects: (params: {
+    page?: number;
+    size?: number;
+    projectName?: string;
+    clubId?: number;
+    status?: string;
+  }) =>
     ['projects', 'list', params] as const,
   postProject: () => ['projects', 'create'] as const,
 } as const;

--- a/packages/shared/src/types/project.ts
+++ b/packages/shared/src/types/project.ts
@@ -1,10 +1,15 @@
 import { ApiResponse, Club, ClubMember } from '@repo/shared/types';
 
+export type ProjectStatus = 'ACTIVE' | 'ENDED';
+
 export interface Project {
   id: number;
   name: string;
   description: string;
-  club: Club;
+  startYear: number;
+  endYear: number | null;
+  status: ProjectStatus;
+  club: Club | null;
   participants: ClubMember[];
 }
 
@@ -20,6 +25,7 @@ export interface ProjectQueryParams {
   projectId?: number;
   projectName?: string;
   clubId?: number;
+  status?: ProjectStatus;
   page: number;
   size: number;
 }


### PR DESCRIPTION
## 개요 💡

- datagsm-server PR #311 스펙에 맞춰 어드민 프로젝트 관리 화면에 상태 및 연도 필드를 반영했습니다.
- 함께 요청된 어드민 테이블 액션 UI 불일치도 같이 정리했습니다.

## 작업내용 ⌨️

- 프로젝트 공용 타입과 API 경로에 status, startYear, endYear 및 종료/재개 API를 추가했습니다.
- 프로젝트 생성/수정 폼, 목록, 필터에 운영 상태와 시작/종료 연도 UI를 반영했습니다.
- API 키 작업 버튼을 가로 정렬로 고정하고, 학생/프로젝트/동아리/API 키 테이블의 마지막 열 헤더를 작업으로 통일했습니다.
## 스크린샷/동영상 📸

<img width="1297" height="110" alt="image" src="https://github.com/user-attachments/assets/cde1534a-07a1-4907-b875-f11221f7b0fd" />

https://github.com/user-attachments/assets/352736b1-8a35-4688-93c8-7380c3dd60d9


