### PR TITLE
v20260426.1

### DIFF
--- a/apps/oauth/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
+++ b/apps/oauth/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -392,12 +391,13 @@ const ResetPasswordForm = () => {
           </button>
 
           <p className={cn('text-muted-foreground text-center text-xs')}>
-            <Link
-              href="/signin"
+            <button
+              type="button"
+              onClick={() => window.close()}
               className={cn('text-foreground font-semibold underline underline-offset-2')}
             >
-              로그인으로 돌아가기
-            </Link>
+              창을 닫고 로그인으로 돌아가기
+            </button>
           </p>
         </div>
       </form>


### PR DESCRIPTION
## 개요 💡

비밀번호 재설정 페이지에서 `로그인으로 돌아가기`를 누르면 존재하지 않는 `/signin` 경로로 이동해 404가 발생하는 문제를 수정했습니다.

## 작업내용 ⌨️

- `/signin` 링크 제거
- 현재 창을 닫고 기존 로그인 화면으로 돌아가도록 버튼 동작 변경
- 회원가입 페이지의 로그인 복귀 동작과 문구를 맞춤