### PR TITLE
[fix] 동아리 폐지연도 null 처리 수정

### DIFF
--- a/apps/admin/src/entities/club/model/schema.ts
+++ b/apps/admin/src/entities/club/model/schema.ts
@@ -21,7 +21,7 @@ export const AddClubSchema = z
       .number({ message: '설립연도를 입력해주세요.' })
       .int()
       .min(1900, { message: '1900년 이후의 연도를 입력해주세요.' }),
-    abolishedYear: z.number().optional(),
+    abolishedYear: z.number().nullable().optional(),
     leaderId: z.number({ message: '동아리 부장을 선택해주세요.' }).min(1).optional(),
     participantIds: z.array(z.number()),
   })
@@ -46,7 +46,7 @@ export const AddClubSchema = z
   .superRefine((data, ctx) => {
     if (data.status !== 'ABOLISHED') return;
 
-    if (data.abolishedYear === undefined) {
+    if (data.abolishedYear == null) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: '폐지연도를 입력해주세요.',

--- a/apps/admin/src/views/clubs/ui/ClubsPage/index.tsx
+++ b/apps/admin/src/views/clubs/ui/ClubsPage/index.tsx
@@ -47,7 +47,7 @@ const ClubsPage = () => {
       type: club.type,
       status: club.status,
       foundedYear: club.foundedYear,
-      abolishedYear: club.abolishedYear,
+      abolishedYear: club.abolishedYear ?? undefined,
       leaderId: club.leader?.id,
       participantIds: club.participants?.map((p) => p.id) ?? [],
     });

--- a/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
+++ b/apps/admin/src/widgets/clubs/ui/ClubFormDialog/index.tsx
@@ -136,7 +136,7 @@ const ClubFormDialog = ({
           type: club.type,
           status: club.status,
           foundedYear: club.foundedYear,
-          abolishedYear: club.abolishedYear,
+          abolishedYear: club.abolishedYear ?? undefined,
           leaderId: club.leader?.id,
           participantIds: club.participants?.map((p) => p.id) ?? [],
         });

--- a/packages/shared/src/types/club.ts
+++ b/packages/shared/src/types/club.ts
@@ -18,7 +18,7 @@ export interface Club {
   type: ClubType;
   status: ClubStatus;
   foundedYear: number;
-  abolishedYear?: number;
+  abolishedYear?: number | null;
   leader: ClubMember | null;
   participants: ClubMember[];
 }


### PR DESCRIPTION
## 개요 💡

동아리 수정 폼에서 API 응답의 `abolishedYear`가 `null`일 때 Zod 검증이 `Invalid input: expected number, received null` 오류를 표시하던 문제를 수정했습니다.

## 작업내용 ⌨️

- 동아리 응답 타입의 `abolishedYear`가 `null`을 허용하도록 변경했습니다.
- 수정 폼 초기화 시 `abolishedYear`의 `null` 값을 `undefined`로 정규화했습니다.
- 동아리 폼 스키마에서 `abolishedYear`가 `null`이어도 처리할 수 있도록 수정했습니다.
- 폐지 상태에서 폐지연도가 없을 때 기존 한국어 검증 메시지가 표시되도록 유지했습니다.

## 관련 이슈 🚨

- 운영 중 동아리처럼 폐지연도가 없는 데이터에서 수정 시 숫자 필드 null 검증 오류가 발생했습니다.

## 리뷰 요청사항 👀

- API 응답과 프론트 타입 간 `abolishedYear` nullable 처리 방향이 적절한지 확인 부탁드립니다.

## 검증

- `pnpm --filter admin check-types`
- `pnpm --filter @repo/shared check-types`
- `pnpm --filter admin lint`
- `pnpm --filter @repo/shared lint`
