### PR TITLE
[docs] Java SDK 의존성 이름 대소문자 수정 롤백

### DIFF
--- a/apps/docs/src/app/api/sdk/java/page.mdx
+++ b/apps/docs/src/app/api/sdk/java/page.mdx
@@ -35,7 +35,7 @@ export const metadata = { title: 'Java / Kotlin SDK' }
 
 <CodeTabs>
   <CodeTab label="Gradle (Kotlin DSL)" language="kotlin" code={`dependencies {
-    implementation("com.github.themoment-team:DataGSM-OpenAPI-SDK-Java:1.7.0")
+    implementation("com.github.themoment-team:datagsm-openapi-sdk-java:1.7.0")
 }
 
 repositories {
@@ -43,7 +43,7 @@ repositories {
 }`} />
 
   <CodeTab label="Gradle (Groovy)" language="groovy" code={`dependencies {
-    implementation 'com.github.themoment-team:DataGSM-OpenAPI-SDK-Java:1.7.0'
+    implementation 'com.github.themoment-team:datagsm-openapi-sdk-java:1.7.0'
 }
 
 repositories {
@@ -60,7 +60,7 @@ repositories {
 <dependencies>
     <dependency>
         <groupId>com.github.themoment-team</groupId>
-        <artifactId>DataGSM-OpenAPI-SDK-Java</artifactId>
+        <artifactId>datagsm-openapi-sdk-java</artifactId>
         <version>1.7.0</version>
     </dependency>
 </dependencies>`} />

--- a/apps/docs/src/app/oauth/sdk/java/page.mdx
+++ b/apps/docs/src/app/oauth/sdk/java/page.mdx
@@ -36,7 +36,7 @@ export const metadata = { title: 'Java / Kotlin SDK' }
 
 <CodeTabs>
   <CodeTab label="Gradle (Kotlin DSL)" language="kotlin" code={`dependencies {
-    implementation("com.github.themoment-team:DataGSM-OAuth-SDK-Java:1.5.0")
+    implementation("com.github.themoment-team:datagsm-oauth-sdk-java:1.5.0")
 }
 
 repositories {
@@ -44,7 +44,7 @@ repositories {
 }`} />
 
   <CodeTab label="Gradle (Groovy)" language="groovy" code={`dependencies {
-    implementation 'com.github.themoment-team:DataGSM-OAuth-SDK-Java:1.5.0'
+    implementation 'com.github.themoment-team:datagsm-oauth-sdk-java:1.5.0'
 }
 
 repositories {
@@ -61,7 +61,7 @@ repositories {
 <dependencies>
     <dependency>
         <groupId>com.github.themoment-team</groupId>
-        <artifactId>DataGSM-OAuth-SDK-Java</artifactId>
+        <artifactId>datagsm-oauth-sdk-java</artifactId>
         <version>1.5.0</version>
     </dependency>
 </dependencies>`} />


### PR DESCRIPTION
## 개요 💡

Java OpenAPI SDK 및 Java OAuth SDK 의존성 이름의 대소문자 수정을 되돌립니다.

## 작업내용 ⌨️

- `docs: Java OpenAPI SDK 의존성 이름 대소문자 수정` 커밋 revert
- `docs: Java OAuth SDK 의존성 이름 대소문자 수정` 커밋 revert