### PR TITLE
[fix] status 페이지 마지막 확인 시각 표기 문제

### DIFF
--- a/apps/status/src/shared/lib/date/formatKoreanTime.ts
+++ b/apps/status/src/shared/lib/date/formatKoreanTime.ts
@@ -1,8 +1,9 @@
-export const formatKoreanTime = (date: Date) =>
-  new Intl.DateTimeFormat('ko-KR', {
-    timeZone: 'Asia/Seoul',
-    hour: 'numeric',
-    minute: 'numeric',
-    second: 'numeric',
-    hour12: true,
-  }).format(date);
+const koreanTimeFormatter = new Intl.DateTimeFormat('ko-KR', {
+  timeZone: 'Asia/Seoul',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+  hour12: true,
+});
+
+export const formatKoreanTime = (date: Date) => koreanTimeFormatter.format(date);

--- a/apps/status/src/shared/lib/date/formatKoreanTime.ts
+++ b/apps/status/src/shared/lib/date/formatKoreanTime.ts
@@ -1,1 +1,8 @@
-export const formatKoreanTime = (date: Date) => date.toLocaleTimeString('ko-KR');
+export const formatKoreanTime = (date: Date) =>
+  new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    hour12: true,
+  }).format(date);


### PR DESCRIPTION
## 개요 💡

status 페이지 마지막 확인 시각 표기 문제 해결

## 작업내용 ⌨️

status 페이지 새로고침시 마지막 확인 시각이 UTC를 표기하던 문제를 해결했습니다

문제 상황

https://github.com/user-attachments/assets/ca6d7f52-79ad-4c86-9e9b-436f64f1e3e7
