### PR TITLE
[docs] `llms.txt`의 Webhook 명칭 통일 및 제거된 콘솔 색인 정리

### DIFF
--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,6 +1,6 @@
 # DataGSM Docs
 
-> 광주소프트웨어마이스터고등학교(GSM)의 학생·동아리·프로젝트·급식·학사일정·시간표 데이터를 중앙집중적으로 제공하는 OpenAPI 및 OAuth 인증 서비스의 공식 기술 문서입니다. 더모먼트팀이 2025년부터 운영하며, GAuth 종료 이후 OAuth 인증 시스템과 데이터 변경을 외부 서버로 실시간 전달하는 Event(Webhook) 기능도 함께 제공합니다.
+> 광주소프트웨어마이스터고등학교(GSM)의 학생·동아리·프로젝트·급식·학사일정·시간표 데이터를 중앙집중적으로 제공하는 OpenAPI 및 OAuth 인증 서비스의 공식 기술 문서입니다. 더모먼트팀이 2025년부터 운영하며, GAuth 종료 이후 OAuth 인증 시스템과 데이터 변경을 외부 서버로 실시간 전달하는 Event 기능도 함께 제공합니다.
 
 ## Docs
 
@@ -30,7 +30,6 @@
 - [OAuth SDK Java](https://docs.datagsm.kr/oauth/sdk/java): Java/Kotlin 환경용 OAuth 클라이언트 SDK
 - [서드파티 권한 범위](https://docs.datagsm.kr/oauth/thirdparty-scope): 서드파티 애플리케이션의 커스텀 OAuth 권한 범위 정의·등록·JWT 포함 흐름, JWK Set 기반 토큰 검증 방법
 - [OAuth SDK React](https://docs.datagsm.kr/oauth/sdk/react): React 환경용 OAuth 클라이언트 SDK
-- [Event 개요](https://docs.datagsm.kr/event): 학생·동아리·프로젝트 이벤트를 외부 서버로 실시간 전달하는 Webhook 기능. 웹 콘솔 기반 관리, 지원 이벤트 9종, 전송·재시도 정책, secret 1회 노출
-- [Event 웹 콘솔에서 관리](https://docs.datagsm.kr/event/console): DataGSM 웹 로그인 후 Event 등록·조회·수정·삭제, 수신 URL·구독 이벤트 설정, secret 보관, 계정당 최대 10개 제한
+- [Event 개요](https://docs.datagsm.kr/event): 학생·동아리·프로젝트 이벤트를 외부 서버로 실시간 전달하는 Event 기능. 지원 이벤트 9종, 전송·재시도 정책, secret 1회 노출, 계정당 최대 10개 제한
 - [이벤트 페이로드 명세](https://docs.datagsm.kr/event/payloads): 이벤트 페이로드 공통 구조(id·event·timestamp·data)와 9종 이벤트별 data 필드 명세 및 예시
 - [서명 검증 가이드](https://docs.datagsm.kr/event/signature): X-DataGSM-Signature(HMAC-SHA256) 서명 검증 절차, 상수 시간 비교, Node·Python·Java·Kotlin 검증 예제

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -30,6 +30,6 @@
 - [OAuth SDK Java](https://docs.datagsm.kr/oauth/sdk/java): Java/Kotlin 환경용 OAuth 클라이언트 SDK
 - [서드파티 권한 범위](https://docs.datagsm.kr/oauth/thirdparty-scope): 서드파티 애플리케이션의 커스텀 OAuth 권한 범위 정의·등록·JWT 포함 흐름, JWK Set 기반 토큰 검증 방법
 - [OAuth SDK React](https://docs.datagsm.kr/oauth/sdk/react): React 환경용 OAuth 클라이언트 SDK
-- [Event 개요](https://docs.datagsm.kr/event): 학생·동아리·프로젝트 이벤트를 외부 서버로 실시간 전달하는 Event 기능. 지원 이벤트 9종, 전송·재시도 정책, secret 1회 노출, 계정당 최대 10개 제한
+- [Event 개요](https://docs.datagsm.kr/event): 학생·동아리·프로젝트 이벤트를 외부 서버로 실시간 전달하는 기능. 지원 이벤트 9종, 전송·재시도 정책, secret 1회 노출, 계정당 최대 10개 제한
 - [이벤트 페이로드 명세](https://docs.datagsm.kr/event/payloads): 이벤트 페이로드 공통 구조(id·event·timestamp·data)와 9종 이벤트별 data 필드 명세 및 예시
 - [서명 검증 가이드](https://docs.datagsm.kr/event/signature): X-DataGSM-Signature(HMAC-SHA256) 서명 검증 절차, 상수 시간 비교, Node·Python·Java·Kotlin 검증 예제


### PR DESCRIPTION
## 개요 💡

기술 문서(MDX)는 모두 `Event` 명칭으로 통일되어 있으나 `apps/docs/public/llms.txt`에만 과거 `Webhook` 명칭이 남아 있었고, 이미 제거된 `event/console` 페이지를 가리키는 색인 항목도 남아 있어 실제 문서 구조와 어긋나 있었습니다. 이를 현행 문서와 일치하도록 정리했습니다.

## 작업내용 ⌨️

- 서비스 설명의 `Event(Webhook) 기능` → `Event 기능`으로 명칭 통일
- Event 개요 색인 설명의 `Webhook 기능` → `Event 기능`으로 수정
- 개요 색인에 남아 있던 `웹 콘솔 기반 관리` 문구 제거 (외부 콘솔 링크 방식으로 전환된 현행과 일치)
- 이미 삭제된 `event/console` 페이지를 가리키던 `Event 웹 콘솔에서 관리` 색인 항목 제거
- `계정당 최대 10개 제한` 정보를 개요 색인 설명으로 흡수

## 리뷰 요청사항 👀

`llms.txt` 색인이 현재 존재하는 Event 문서 3종(개요·페이로드·서명 검증)과 일치하는지 확인 부탁드립니다.
