### PR TITLE
[docs] docs 페이지 메타데이터 및 동적 OG 이미지 적용

### DIFF
--- a/apps/docs/src/app/api/http/club/page.mdx
+++ b/apps/docs/src/app/api/http/club/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: '동아리 데이터 OpenAPI' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "동아리 데이터 OpenAPI", pathname: "/api/http/club" })
 
 # 동아리 데이터 OpenAPI
 

--- a/apps/docs/src/app/api/http/neis/meals/page.mdx
+++ b/apps/docs/src/app/api/http/neis/meals/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: '급식 데이터 API' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "급식 데이터 API", pathname: "/api/http/neis/meals" })
 
 # 급식 데이터 API
 

--- a/apps/docs/src/app/api/http/neis/page.mdx
+++ b/apps/docs/src/app/api/http/neis/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'NEIS 데이터 OpenAPI' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "NEIS 데이터 OpenAPI", pathname: "/api/http/neis" })
 
 # NEIS 데이터 OpenAPI
 

--- a/apps/docs/src/app/api/http/neis/schedules/page.mdx
+++ b/apps/docs/src/app/api/http/neis/schedules/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: '학사일정 데이터 API' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "학사일정 데이터 API", pathname: "/api/http/neis/schedules" })
 
 # 학사일정 데이터 API
 

--- a/apps/docs/src/app/api/http/neis/timetables/page.mdx
+++ b/apps/docs/src/app/api/http/neis/timetables/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: '시간표 데이터 API' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "시간표 데이터 API", pathname: "/api/http/neis/timetables" })
 
 # 시간표 데이터 API
 

--- a/apps/docs/src/app/api/http/page.mdx
+++ b/apps/docs/src/app/api/http/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'HTTP OpenAPI' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "HTTP OpenAPI", pathname: "/api/http" })
 
 # DataGSM HTTP OpenAPI Overview
 
@@ -139,4 +141,3 @@ async function fetchWithCache(url, apiKey, cachedETag) {
 - [NEIS 데이터 OpenAPI](/api/http/neis)
 
 SDK를 사용한 더 편리한 API 호출을 원한다면 [SDK 기술 문서](/api/sdk)를 참고하세요.
-

--- a/apps/docs/src/app/api/http/project/page.mdx
+++ b/apps/docs/src/app/api/http/project/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: '프로젝트 데이터 OpenAPI' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "프로젝트 데이터 OpenAPI", pathname: "/api/http/project" })
 
 # 프로젝트 데이터 OpenAPI
 

--- a/apps/docs/src/app/api/http/student/page.mdx
+++ b/apps/docs/src/app/api/http/student/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: '학생 데이터 OpenAPI' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "학생 데이터 OpenAPI", pathname: "/api/http/student" })
 
 # 학생 데이터 OpenAPI
 

--- a/apps/docs/src/app/api/page.mdx
+++ b/apps/docs/src/app/api/page.mdx
@@ -1,6 +1,8 @@
 import { AlertCircle } from 'lucide-react'
 
-export const metadata = { title: 'OpenAPI' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "OpenAPI", pathname: "/api" })
 
 # OpenAPI
 
@@ -78,4 +80,3 @@ API 키는 각각의 요청량 제한(Rate Limit)이 적용됩니다. 이를 초
 - **정기 갱신**: API 키를 정기적으로 갱신하여 보안을 강화합니다.
 - **안전한 저장**: API 키를 안전하게 저장하고, 공개 저장소에 노출되지 않도록 주의합니다.
 - **불필요한 키 폐기**: 더 이상 사용하지 않는 API 키는 즉시 폐기합니다.
-

--- a/apps/docs/src/app/api/sdk/dotnet/page.mdx
+++ b/apps/docs/src/app/api/sdk/dotnet/page.mdx
@@ -1,6 +1,8 @@
 import { AlertTriangle } from 'lucide-react'
 
-export const metadata = { title: '.NET SDK' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: ".NET SDK", pathname: "/api/sdk/dotnet" })
 
 # DataGSM OpenAPI SDK for .NET
 

--- a/apps/docs/src/app/api/sdk/go/page.mdx
+++ b/apps/docs/src/app/api/sdk/go/page.mdx
@@ -1,6 +1,8 @@
 import { AlertTriangle } from 'lucide-react'
 
-export const metadata = { title: 'Go SDK' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "Go SDK", pathname: "/api/sdk/go" })
 
 # DataGSM OpenAPI SDK for Go
 

--- a/apps/docs/src/app/api/sdk/java/page.mdx
+++ b/apps/docs/src/app/api/sdk/java/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'Java / Kotlin SDK' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "Java / Kotlin SDK", pathname: "/api/sdk/java" })
 
 # DataGSM OpenAPI SDK Java / Kotlin
 

--- a/apps/docs/src/app/api/sdk/javascript/page.mdx
+++ b/apps/docs/src/app/api/sdk/javascript/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'JavaScript / TypeScript SDK' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "JavaScript / TypeScript SDK", pathname: "/api/sdk/javascript" })
 
 # DataGSM OpenAPI SDK for JavaScript / TypeScript
 

--- a/apps/docs/src/app/api/sdk/page.mdx
+++ b/apps/docs/src/app/api/sdk/page.mdx
@@ -1,6 +1,8 @@
 import { AlertTriangle } from 'lucide-react'
 
-export const metadata = { title: 'DataGSM OpenAPI SDK' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "DataGSM OpenAPI SDK", pathname: "/api/sdk" })
 
 # DataGSM OpenAPI SDK Overview
 

--- a/apps/docs/src/app/api/sdk/python/page.mdx
+++ b/apps/docs/src/app/api/sdk/python/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'Python SDK' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "Python SDK", pathname: "/api/sdk/python" })
 
 # DataGSM OpenAPI SDK Python
 

--- a/apps/docs/src/app/api/sdk/versioning/page.mdx
+++ b/apps/docs/src/app/api/sdk/versioning/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'DataGSM OpenAPI SDK 버저닝 컨벤션' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "DataGSM OpenAPI SDK 버저닝 컨벤션", pathname: "/api/sdk/versioning" })
 
 # DataGSM OpenAPI SDK 버저닝 컨벤션
 

--- a/apps/docs/src/app/event/page.mdx
+++ b/apps/docs/src/app/event/page.mdx
@@ -1,6 +1,8 @@
 import { Shield } from 'lucide-react'
 
-export const metadata = { title: 'Event' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "Event", pathname: "/event" })
 
 # Event
 

--- a/apps/docs/src/app/event/payloads/club/page.mdx
+++ b/apps/docs/src/app/event/payloads/club/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'club.updated 명세' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "club.updated 명세", pathname: "/event/payloads/club" })
 
 # `club.updated`
 

--- a/apps/docs/src/app/event/payloads/page.mdx
+++ b/apps/docs/src/app/event/payloads/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: '이벤트 페이로드 명세' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "이벤트 페이로드 명세", pathname: "/event/payloads" })
 
 # 이벤트 페이로드 명세
 

--- a/apps/docs/src/app/event/payloads/project/page.mdx
+++ b/apps/docs/src/app/event/payloads/project/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'project.updated 명세' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "project.updated 명세", pathname: "/event/payloads/project" })
 
 # `project.updated`
 

--- a/apps/docs/src/app/event/payloads/student/page.mdx
+++ b/apps/docs/src/app/event/payloads/student/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'student.updated 명세' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "student.updated 명세", pathname: "/event/payloads/student" })
 
 # `student.updated`
 

--- a/apps/docs/src/app/event/signature/page.mdx
+++ b/apps/docs/src/app/event/signature/page.mdx
@@ -1,6 +1,8 @@
 import { Shield } from 'lucide-react'
 
-export const metadata = { title: '서명 검증 가이드' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "서명 검증 가이드", pathname: "/event/signature" })
 
 # 서명 검증 가이드
 

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -4,9 +4,9 @@ import localFont from 'next/font/local';
 import { TanStackProvider } from '@repo/shared/lib';
 import { Header } from '@repo/shared/ui';
 import { cn } from '@repo/shared/utils';
-import type { Metadata } from 'next';
 
 import '@/shared/styles/globals.css';
+import { docsRootMetadata } from '@/shared/lib/metadata';
 import { DocsSidebar } from '@/widgets/docs';
 
 const pressStart2P = Press_Start_2P({
@@ -36,24 +36,7 @@ const dmSans = DM_Sans({
   variable: '--font-sans',
 });
 
-export const metadata: Metadata = {
-  title: {
-    template: 'DataGSM Docs | %s',
-    default: 'DataGSM Docs',
-  },
-  description: '광주소프트웨어마이스터고등학교 DataGSM 기술 문서',
-  openGraph: {
-    title: {
-      template: 'DataGSM Docs | %s',
-      default: 'DataGSM Docs',
-    },
-    description: '광주소프트웨어마이스터고등학교 DataGSM 기술 문서',
-    url: 'https://docs.datagsm.kr/',
-    siteName: 'DataGSM',
-    images: 'https://docs.datagsm.kr/images/og-image.png',
-    type: 'website',
-  },
-};
+export const metadata = docsRootMetadata;
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (

--- a/apps/docs/src/app/oauth/design/page.mdx
+++ b/apps/docs/src/app/oauth/design/page.mdx
@@ -1,6 +1,8 @@
 import { Download } from 'lucide-react'
 
-export const metadata = { title: 'Login Button Design' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "Login Button Design", pathname: "/oauth/design" })
 
 # Login Button Design Guidelines
 

--- a/apps/docs/src/app/oauth/examples/nextjs-spring-boot/page.mdx
+++ b/apps/docs/src/app/oauth/examples/nextjs-spring-boot/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'Next.js + Spring Boot' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "Next.js + Spring Boot", pathname: "/oauth/examples/nextjs-spring-boot" })
 
 # Next.js + Spring Boot OAuth 구현
 

--- a/apps/docs/src/app/oauth/examples/page.mdx
+++ b/apps/docs/src/app/oauth/examples/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'OAuth 구현 예제' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "OAuth 구현 예제", pathname: "/oauth/examples" })
 
 import { Shield } from 'lucide-react'
 

--- a/apps/docs/src/app/oauth/examples/react-spring-boot-kotlin/page.mdx
+++ b/apps/docs/src/app/oauth/examples/react-spring-boot-kotlin/page.mdx
@@ -1,6 +1,8 @@
 import { Shield } from 'lucide-react'
 
-export const metadata = { title: 'React + Spring Boot (Kotlin)' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "React + Spring Boot (Kotlin)", pathname: "/oauth/examples/react-spring-boot-kotlin" })
 
 # React + Spring Boot (Kotlin) OAuth 구현
 

--- a/apps/docs/src/app/oauth/examples/react-spring-boot/page.mdx
+++ b/apps/docs/src/app/oauth/examples/react-spring-boot/page.mdx
@@ -1,6 +1,8 @@
 import { Shield, CheckCircle2 } from 'lucide-react'
 
-export const metadata = { title: 'React + Spring Boot (BFF)' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "React + Spring Boot (BFF)", pathname: "/oauth/examples/react-spring-boot" })
 
 # React + Spring Boot Kotlin OAuth 구현 (BFF 패턴)
 

--- a/apps/docs/src/app/oauth/examples/vanilla-nestjs/page.mdx
+++ b/apps/docs/src/app/oauth/examples/vanilla-nestjs/page.mdx
@@ -1,6 +1,8 @@
 import { Shield } from 'lucide-react'
 
-export const metadata = { title: 'Vanilla JS + NestJS' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "Vanilla JS + NestJS", pathname: "/oauth/examples/vanilla-nestjs" })
 
 # Vanilla JavaScript + NestJS OAuth 구현
 

--- a/apps/docs/src/app/oauth/http/authorize/page.mdx
+++ b/apps/docs/src/app/oauth/http/authorize/page.mdx
@@ -1,6 +1,8 @@
 import { Shield, ArrowRight } from 'lucide-react'
 
-export const metadata = { title: '인증 흐름 시작' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "인증 흐름 시작", pathname: "/oauth/http/authorize" })
 
 # 인증 흐름 시작
 

--- a/apps/docs/src/app/oauth/http/page.mdx
+++ b/apps/docs/src/app/oauth/http/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'OAuth HTTP API' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "OAuth HTTP API", pathname: "/oauth/http" })
 
 # OAuth HTTP API
 

--- a/apps/docs/src/app/oauth/http/token-exchange/page.mdx
+++ b/apps/docs/src/app/oauth/http/token-exchange/page.mdx
@@ -1,6 +1,8 @@
 import { Shield } from 'lucide-react'
 
-export const metadata = { title: '토큰 교환' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "토큰 교환", pathname: "/oauth/http/token-exchange" })
 
 # 토큰 교환
 

--- a/apps/docs/src/app/oauth/http/token-refresh/page.mdx
+++ b/apps/docs/src/app/oauth/http/token-refresh/page.mdx
@@ -1,6 +1,8 @@
 import { Shield } from 'lucide-react'
 
-export const metadata = { title: '토큰 갱신' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "토큰 갱신", pathname: "/oauth/http/token-refresh" })
 
 # 토큰 갱신
 

--- a/apps/docs/src/app/oauth/http/userinfo/page.mdx
+++ b/apps/docs/src/app/oauth/http/userinfo/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: '사용자 데이터 조회' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "사용자 데이터 조회", pathname: "/oauth/http/userinfo" })
 
 # 사용자 데이터 조회
 

--- a/apps/docs/src/app/oauth/page.mdx
+++ b/apps/docs/src/app/oauth/page.mdx
@@ -1,6 +1,8 @@
 import { Shield } from 'lucide-react'
 
-export const metadata = { title: 'OAuth' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "OAuth", pathname: "/oauth" })
 
 # OAuth
 

--- a/apps/docs/src/app/oauth/pkce/page.mdx
+++ b/apps/docs/src/app/oauth/pkce/page.mdx
@@ -1,6 +1,8 @@
 import { Shield, AlertTriangle } from 'lucide-react'
 
-export const metadata = { title: 'PKCE 가이드' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "PKCE 가이드", pathname: "/oauth/pkce" })
 
 # PKCE (Proof Key for Code Exchange)
 

--- a/apps/docs/src/app/oauth/sdk/java/page.mdx
+++ b/apps/docs/src/app/oauth/sdk/java/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'Java / Kotlin SDK' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "Java / Kotlin SDK", pathname: "/oauth/sdk/java" })
 
 # DataGSM OAuth SDK Java / Kotlin
 

--- a/apps/docs/src/app/oauth/sdk/page.mdx
+++ b/apps/docs/src/app/oauth/sdk/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'DataGSM OAuth SDK Overview' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "DataGSM OAuth SDK Overview", pathname: "/oauth/sdk" })
 
 # DataGSM OAuth SDK Overview
 

--- a/apps/docs/src/app/oauth/sdk/react/page.mdx
+++ b/apps/docs/src/app/oauth/sdk/react/page.mdx
@@ -1,6 +1,8 @@
 import { Shield } from 'lucide-react'
 
-export const metadata = { title: 'React SDK' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "React SDK", pathname: "/oauth/sdk/react" })
 
 # DataGSM OAuth SDK for React
 
@@ -27,7 +29,6 @@ export const metadata = { title: 'React SDK' }
     </div>
   </div>
 </div>
-
 
 ### 주요 특징
 
@@ -117,7 +118,6 @@ export default App;
 | --- | --- | --- | --- |
 | `children` | `ReactNode` | 선택 | 버튼 내부에 렌더링될 내용. 기본값은 "Data GSM 로그인"입니다. |
 | `onClick` | `(event) => void` | 선택 | 기본 `login` 함수 호출 전에 실행할 커스텀 클릭 핸들러. |
-
 
 ### useOAuth Hook 사용하기
 

--- a/apps/docs/src/app/oauth/sdk/versioning/page.mdx
+++ b/apps/docs/src/app/oauth/sdk/versioning/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'DataGSM OAuth SDK 버저닝 컨벤션' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "DataGSM OAuth SDK 버저닝 컨벤션", pathname: "/oauth/sdk/versioning" })
 
 # DataGSM OAuth SDK 버저닝 컨벤션
 

--- a/apps/docs/src/app/oauth/thirdparty-scope/page.mdx
+++ b/apps/docs/src/app/oauth/thirdparty-scope/page.mdx
@@ -1,6 +1,8 @@
 import { Shield, Key, AlertCircle } from 'lucide-react'
 
-export const metadata = { title: '서드파티 권한 범위' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "서드파티 권한 범위", pathname: "/oauth/thirdparty-scope" })
 
 # 서드파티 권한 범위
 

--- a/apps/docs/src/app/og/route.tsx
+++ b/apps/docs/src/app/og/route.tsx
@@ -1,0 +1,149 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { ImageResponse } from 'next/og';
+
+const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const runtime = 'nodejs';
+
+const titleFontPath = join(process.cwd(), 'node_modules/galmuri/dist/Galmuri11-Bold.ttf');
+const bodyFontPath = join(process.cwd(), 'node_modules/galmuri/dist/Galmuri11.ttf');
+const logoPath = join(process.cwd(), 'public/images/docs/D_black.svg');
+
+const titleFontDataPromise = readFile(titleFontPath);
+const bodyFontDataPromise = readFile(bodyFontPath);
+const logoDataPromise = readFile(logoPath, 'utf8');
+
+const fallbackTitle = 'Overview';
+const maxTitleLength = 64;
+
+const sanitizeTitle = (title: string | null) => {
+  if (!title) {
+    return fallbackTitle;
+  }
+
+  const normalizedTitle = title.trim().replace(/\s+/g, ' ');
+
+  if (!normalizedTitle) {
+    return fallbackTitle;
+  }
+
+  return normalizedTitle.slice(0, maxTitleLength);
+};
+
+const createLogoDataUrl = (logo: string) => `data:image/svg+xml;base64,${Buffer.from(logo).toString('base64')}`;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const title = sanitizeTitle(searchParams.get('title'));
+
+  const [titleFontData, bodyFontData, logo] = await Promise.all([
+    titleFontDataPromise,
+    bodyFontDataPromise,
+    logoDataPromise,
+  ]);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          position: 'relative',
+          overflow: 'hidden',
+          background: '#fafafa',
+          color: '#101418',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            background:
+              'linear-gradient(180deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0))',
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            inset: 30,
+            border: '1px solid rgba(16, 20, 24, 0.08)',
+            borderRadius: 28,
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            left: 76,
+            bottom: 74,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 24,
+            width: 860,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 16,
+              color: '#101418',
+              fontFamily: 'Galmuri Title',
+              fontSize: 30,
+              letterSpacing: '-0.035em',
+            }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={createLogoDataUrl(logo)}
+              alt="DataGSM logo"
+              width="56"
+              height="56"
+              style={{
+                width: 56,
+                height: 56,
+              }}
+            />
+            <div style={{ display: 'flex' }}>DataGSM</div>
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              maxWidth: '100%',
+              fontFamily: 'Galmuri Title',
+              fontSize: 64,
+              lineHeight: 1.24,
+              letterSpacing: '-0.045em',
+              textWrap: 'balance',
+              textShadow: '0 1px 0 rgba(255, 255, 255, 0.7)',
+            }}
+          >
+            {title}
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [
+        {
+          name: 'Galmuri Title',
+          data: titleFontData,
+          style: 'normal',
+          weight: 700,
+        },
+        {
+          name: 'Galmuri Body',
+          data: bodyFontData,
+          style: 'normal',
+          weight: 400,
+        },
+      ],
+    },
+  );
+}

--- a/apps/docs/src/app/og/route.tsx
+++ b/apps/docs/src/app/og/route.tsx
@@ -14,12 +14,16 @@ const titleFontPath = join(process.cwd(), 'node_modules/galmuri/dist/Galmuri11-B
 const bodyFontPath = join(process.cwd(), 'node_modules/galmuri/dist/Galmuri11.ttf');
 const logoPath = join(process.cwd(), 'public/images/docs/D_black.svg');
 
-const titleFontDataPromise = readFile(titleFontPath);
-const bodyFontDataPromise = readFile(bodyFontPath);
-const logoDataPromise = readFile(logoPath, 'utf8');
-
 const fallbackTitle = 'Overview';
 const maxTitleLength = 64;
+
+type OgAssets = {
+  titleFontData: Buffer;
+  bodyFontData: Buffer;
+  logo: string;
+};
+
+let ogAssetsPromise: Promise<OgAssets> | null = null;
 
 const sanitizeTitle = (title: string | null) => {
   if (!title) {
@@ -37,15 +41,39 @@ const sanitizeTitle = (title: string | null) => {
 
 const createLogoDataUrl = (logo: string) => `data:image/svg+xml;base64,${Buffer.from(logo).toString('base64')}`;
 
+const loadOgAssets = async () => {
+  if (!ogAssetsPromise) {
+    ogAssetsPromise = Promise.all([
+      readFile(titleFontPath),
+      readFile(bodyFontPath),
+      readFile(logoPath, 'utf8'),
+    ])
+      .then(([titleFontData, bodyFontData, logo]) => ({
+        titleFontData,
+        bodyFontData,
+        logo,
+      }))
+      .catch((error) => {
+        ogAssetsPromise = null;
+        throw error;
+      });
+  }
+
+  return ogAssetsPromise;
+};
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const title = sanitizeTitle(searchParams.get('title'));
 
-  const [titleFontData, bodyFontData, logo] = await Promise.all([
-    titleFontDataPromise,
-    bodyFontDataPromise,
-    logoDataPromise,
-  ]);
+  let assets: OgAssets;
+
+  try {
+    assets = await loadOgAssets();
+  } catch (error) {
+    console.error('Failed to load OG image assets', error);
+    return new Response('Failed to generate OG image', { status: 500 });
+  }
 
   return new ImageResponse(
     (
@@ -91,22 +119,22 @@ export async function GET(request: Request) {
             style={{
               display: 'flex',
               alignItems: 'center',
-              gap: 16,
+              gap: 12,
               color: '#101418',
               fontFamily: 'Galmuri Title',
-              fontSize: 30,
+              fontSize: 24,
               letterSpacing: '-0.035em',
             }}
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
-              src={createLogoDataUrl(logo)}
+              src={createLogoDataUrl(assets.logo)}
               alt="DataGSM logo"
-              width="56"
-              height="56"
+              width="20"
+              height="20"
               style={{
-                width: 56,
-                height: 56,
+                width: 20,
+                height: 20,
               }}
             />
             <div style={{ display: 'flex' }}>DataGSM</div>
@@ -133,13 +161,13 @@ export async function GET(request: Request) {
       fonts: [
         {
           name: 'Galmuri Title',
-          data: titleFontData,
+          data: assets.titleFontData,
           style: 'normal',
           weight: 700,
         },
         {
           name: 'Galmuri Body',
-          data: bodyFontData,
+          data: assets.bodyFontData,
           style: 'normal',
           weight: 400,
         },

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -1,4 +1,6 @@
-export const metadata = { title: 'DataGSM Docs | Overview' }
+import { createDocsPageMetadata } from '@/shared/lib/metadata';
+
+export const metadata = createDocsPageMetadata({ title: "Overview", pathname: "/", absoluteTitle: true })
 
 # Overview
 

--- a/apps/docs/src/shared/lib/metadata.ts
+++ b/apps/docs/src/shared/lib/metadata.ts
@@ -1,0 +1,97 @@
+import type { Metadata } from 'next';
+
+const DOCS_URL = 'https://docs.datagsm.kr';
+const DOCS_DESCRIPTION = '광주소프트웨어마이스터고등학교 DataGSM 기술 문서';
+
+type CreateDocsPageMetadataOptions = {
+  title: string;
+  pathname: string;
+  description?: string;
+  absoluteTitle?: boolean;
+};
+
+const normalizePathname = (pathname: string) => {
+  if (!pathname || pathname === '/') {
+    return '/';
+  }
+
+  return pathname.startsWith('/') ? pathname : `/${pathname}`;
+};
+
+const createFullTitle = (title: string) => `DataGSM Docs | ${title}`;
+
+export const docsMetadataBase = new URL(DOCS_URL);
+
+export const createDocsPageMetadata = ({
+  title,
+  pathname,
+  description = DOCS_DESCRIPTION,
+  absoluteTitle = false,
+}: CreateDocsPageMetadataOptions): Metadata => {
+  const normalizedPathname = normalizePathname(pathname);
+  const fullTitle = createFullTitle(title);
+  const ogImageUrl = new URL('/og', docsMetadataBase);
+
+  ogImageUrl.searchParams.set('title', title);
+
+  return {
+    title: absoluteTitle ? fullTitle : title,
+    description,
+    alternates: {
+      canonical: normalizedPathname,
+    },
+    openGraph: {
+      title: fullTitle,
+      description,
+      url: normalizedPathname,
+      siteName: 'DataGSM',
+      locale: 'ko_KR',
+      type: 'website',
+      images: [
+        {
+          url: ogImageUrl.toString(),
+          width: 1200,
+          height: 630,
+          alt: fullTitle,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: fullTitle,
+      description,
+      images: [ogImageUrl.toString()],
+    },
+  };
+};
+
+export const docsRootMetadata: Metadata = {
+  metadataBase: docsMetadataBase,
+  title: {
+    template: 'DataGSM Docs | %s',
+    default: 'DataGSM Docs',
+  },
+  description: DOCS_DESCRIPTION,
+  openGraph: {
+    title: 'DataGSM Docs',
+    description: DOCS_DESCRIPTION,
+    url: '/',
+    siteName: 'DataGSM',
+    locale: 'ko_KR',
+    type: 'website',
+    images: [
+      {
+        url: 'https://docs.datagsm.kr/og?title=Overview',
+        width: 1200,
+        height: 630,
+        alt: 'DataGSM Docs | Overview',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'DataGSM Docs',
+    description: DOCS_DESCRIPTION,
+    images: ['https://docs.datagsm.kr/og?title=Overview'],
+  },
+};


### PR DESCRIPTION
## 개요 💡

`docs` 앱의 메타데이터를 페이지별로 정리하고, 고정 OG 이미지를 페이지별 동적 OG 이미지로 전환합니다.

## 작업내용 ⌨️

- `apps/docs/src/shared/lib/metadata.ts`에 docs 전용 메타데이터 helper 추가
- 각 MDX 문서 페이지가 `title`, `og:title`, `og:url`, `twitter:image`를 페이지별로 생성하도록 변경
- `apps/docs/src/app/og/route.tsx`를 추가해 문서 제목 기반 동적 OG 이미지 생성
- `apps/docs/src/app/layout.tsx`의 전역 metadata를 공통 helper 기반으로 정리

## 스크린샷/동영상 📸

<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/23a1de3c-991b-4d79-bc7a-9e393e38e707" />

## 리뷰 요청사항 👀

- docs 페이지별 메타데이터 상속 방식과 동적 OG 이미지 구성 방향이 의도에 맞는지 확인 부탁드립니다.
