### PR TITLE
feat: event url 검증 상태 추가

### DIFF
--- a/apps/client/src/entities/events/model/types.ts
+++ b/apps/client/src/entities/events/model/types.ts
@@ -1,11 +1,14 @@
 import { ApiResponse } from '@repo/shared/types';
 
+export type VerificationStatus = 'PENDING' | 'VERIFIED' | 'FAILED';
+
 export interface Event {
   id: number;
   target_url: string;
   events: string[];
   is_active: boolean;
   created_at: string;
+  verification_status: VerificationStatus;
 }
 
 export interface EventListData {

--- a/apps/client/src/widgets/events/ui/EventList/index.tsx
+++ b/apps/client/src/widgets/events/ui/EventList/index.tsx
@@ -24,7 +24,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Pencil, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { Event } from '@/entities/events';
+import { Event, VerificationStatus } from '@/entities/events';
 import { useDeleteEvent } from '@/widgets/events';
 
 interface EventListProps {
@@ -45,10 +45,27 @@ const formatDate = (value: string) => {
   return date.toLocaleString('ko-KR');
 };
 
+const VERIFICATION_STATUS_META: Record<
+  VerificationStatus,
+  { label: string; className: string }
+> = {
+  VERIFIED: { label: 'verified', className: 'border-foreground text-foreground' },
+  PENDING: { label: 'pending', className: 'border-muted-foreground/40 text-muted-foreground' },
+  FAILED: { label: 'failed', className: 'border-destructive text-destructive' },
+};
+
 const EventListItem = ({ event, onEdit, onDelete }: EventListItemProps) => {
+  const isVerificationFailed = event.verification_status === 'FAILED';
+  const verificationMeta = VERIFICATION_STATUS_META[event.verification_status];
+
   return (
     <TableRow>
-      <TableCell className={cn('max-w-xs truncate font-mono text-sm')}>
+      <TableCell
+        className={cn(
+          'max-w-xs truncate font-mono text-sm',
+          isVerificationFailed && 'text-destructive',
+        )}
+      >
         {event.target_url}
       </TableCell>
       <TableCell>
@@ -73,6 +90,16 @@ const EventListItem = ({ event, onEdit, onDelete }: EventListItemProps) => {
           )}
         >
           {event.is_active ? 'active' : 'inactive'}
+        </span>
+      </TableCell>
+      <TableCell>
+        <span
+          className={cn(
+            'border px-1.5 py-0.5 font-mono text-xs uppercase',
+            verificationMeta.className,
+          )}
+        >
+          {verificationMeta.label}
         </span>
       </TableCell>
       <TableCell className={cn('text-muted-foreground font-mono text-xs')}>
@@ -139,6 +166,7 @@ const EventList = ({ events, isLoading, onEdit }: EventListProps) => {
           <TableHead>수신 URL</TableHead>
           <TableHead>구독 이벤트</TableHead>
           <TableHead>상태</TableHead>
+          <TableHead>검증 상태</TableHead>
           <TableHead>생성일</TableHead>
           <TableHead className={cn('w-24')}>작업</TableHead>
         </TableRow>
@@ -152,6 +180,9 @@ const EventList = ({ events, isLoading, onEdit }: EventListProps) => {
               </TableCell>
               <TableCell>
                 <Skeleton className={cn('h-4 w-40')} />
+              </TableCell>
+              <TableCell>
+                <Skeleton className={cn('h-4 w-16')} />
               </TableCell>
               <TableCell>
                 <Skeleton className={cn('h-4 w-16')} />
@@ -175,7 +206,7 @@ const EventList = ({ events, isLoading, onEdit }: EventListProps) => {
           ))
         ) : (
           <TableRow>
-            <TableCell colSpan={5} className={cn('text-muted-foreground h-24 text-center font-mono')}>
+            <TableCell colSpan={6} className={cn('text-muted-foreground h-24 text-center font-mono')}>
               {'>'} 등록된 이벤트가 없습니다.
             </TableCell>
           </TableRow>


### PR DESCRIPTION
## 개요 💡

event url 검증 상태 표시

## 작업내용 ⌨️

- `Event` 타입에 `verification_status` 필드(`PENDING | VERIFIED | FAILED`) 및 `VerificationStatus` 타입 추가
- 이벤트 목록 테이블에 **"검증 상태"** 컬럼 신규 추가
  - `VERIFIED` → `verified` (기본 스타일)
  - `PENDING` → `pending` (muted 스타일)
  - `FAILED` → `failed` (destructive/빨간색 강조)
- `FAILED` 상태인 경우 수신 URL 텍스트도 빨간색으로 강조하여 사용자에게 URL 수정을 유도
- 컬럼 추가에 따른 스켈레톤 셀 및 빈 상태 `colSpan` 조정

## 스크린샷/동영상 📸

<img width="1562" height="301" alt="image" src="https://github.com/user-attachments/assets/1f7ea618-1657-45b2-8c39-3aabadfc67d5" />

## 관련 이슈 🚨

#190