### PR TITLE
[feat] 계정 관리 페이지 및 권한 변경 기능 추가

### DIFF
--- a/apps/admin/src/app/accounts/page.tsx
+++ b/apps/admin/src/app/accounts/page.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from 'react';
+
+import { AccountsPage } from '@/views/accounts';
+
+const Accounts = async () => {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <AccountsPage />
+    </Suspense>
+  );
+};
+
+export default Accounts;

--- a/apps/admin/src/entities/account/index.ts
+++ b/apps/admin/src/entities/account/index.ts
@@ -1,0 +1,2 @@
+export * from './model/schema';
+export * from './lib/utils';

--- a/apps/admin/src/entities/account/lib/utils.ts
+++ b/apps/admin/src/entities/account/lib/utils.ts
@@ -1,0 +1,23 @@
+import { UserRoleType } from '@repo/shared/types';
+
+export const getAccountRoleLabel = (role: UserRoleType) => {
+  switch (role) {
+    case 'ROOT':
+      return '루트';
+    case 'ADMIN':
+      return '어드민';
+    case 'USER':
+      return '유저';
+  }
+};
+
+export const getAccountRoleBadgeStyle = (role: UserRoleType) => {
+  switch (role) {
+    case 'ROOT':
+      return 'bg-destructive text-white border-destructive';
+    case 'ADMIN':
+      return 'bg-foreground text-background border-foreground';
+    case 'USER':
+      return 'border-foreground/25 text-foreground';
+  }
+};

--- a/apps/admin/src/entities/account/model/schema.ts
+++ b/apps/admin/src/entities/account/model/schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const AccountFilterSchema = z.object({
+  email: z.string().optional(),
+  role: z.string().optional(),
+  isStudent: z.string().optional(),
+  sortBy: z.string().optional(),
+});
+
+export type AccountFilterType = z.infer<typeof AccountFilterSchema>;

--- a/apps/admin/src/entities/signin/index.ts
+++ b/apps/admin/src/entities/signin/index.ts
@@ -1,2 +1,3 @@
 export * from './model/types';
 export * from './model/useGetRole';
+export * from './model/useGetMyAccountId';

--- a/apps/admin/src/entities/signin/model/useGetMyAccountId.ts
+++ b/apps/admin/src/entities/signin/model/useGetMyAccountId.ts
@@ -1,0 +1,14 @@
+import { accountQueryKeys, accountUrl, get } from '@repo/shared/api';
+import { AccountResponse } from '@repo/shared/types';
+import { useQuery } from '@tanstack/react-query';
+
+export const useGetMyAccountId = () => {
+  return useQuery({
+    queryKey: accountQueryKeys.getMy(),
+    queryFn: () => get<AccountResponse>(accountUrl.getMy()),
+    select: (data) => data.data.id,
+    staleTime: 0,
+    gcTime: 0,
+    retry: false,
+  });
+};

--- a/apps/admin/src/views/accounts/index.ts
+++ b/apps/admin/src/views/accounts/index.ts
@@ -1,0 +1,2 @@
+export * from './model/useGetAccounts';
+export { default as AccountsPage } from './ui/AccountsPage';

--- a/apps/admin/src/views/accounts/model/useGetAccounts.ts
+++ b/apps/admin/src/views/accounts/model/useGetAccounts.ts
@@ -1,0 +1,28 @@
+import { accountQueryKeys, accountUrl, get } from '@repo/shared/api';
+import { AccountListResponse, AccountSortBy, UserRoleType } from '@repo/shared/types';
+import { minutesToMs } from '@repo/shared/utils';
+import { UseQueryOptions, useQuery } from '@tanstack/react-query';
+
+interface UseGetAccountsParams {
+  page?: number;
+  size?: number;
+  email?: string;
+  role?: UserRoleType;
+  isStudent?: boolean;
+  sortBy?: AccountSortBy;
+}
+
+export const useGetAccounts = (
+  params: UseGetAccountsParams,
+  options?: Omit<UseQueryOptions<AccountListResponse>, 'queryKey' | 'queryFn'>,
+) =>
+  useQuery({
+    queryKey: accountQueryKeys.getAccounts(params),
+    queryFn: () => get<AccountListResponse>(accountUrl.getAccounts(params)),
+    staleTime: minutesToMs(5),
+    gcTime: minutesToMs(10),
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    ...options,
+  });

--- a/apps/admin/src/views/accounts/ui/AccountsPage/index.tsx
+++ b/apps/admin/src/views/accounts/ui/AccountsPage/index.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { useSearchParams } from 'next/navigation';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useDebounce, useURLFilters } from '@repo/shared/hooks';
+import { AccountListItem, AccountSortBy, UserRoleType } from '@repo/shared/types';
+import { CommonPagination, PageHeader } from '@repo/shared/ui';
+import { cn } from '@repo/shared/utils';
+
+import { useForm, useWatch } from 'react-hook-form';
+
+import { AccountFilterSchema, AccountFilterType } from '@/entities/account';
+import { useGetAccounts } from '@/views/accounts';
+import { AccountDetailDialog, AccountFilter, AccountList } from '@/widgets/accounts';
+
+const PAGE_SIZE = 10;
+
+const AccountsPage = () => {
+  const searchParams = useSearchParams();
+  const { updateURL } = useURLFilters<AccountFilterType>();
+
+  const [selectedAccount, setSelectedAccount] = useState<AccountListItem | null>(null);
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
+
+  const handleSelectAccount = (account: AccountListItem) => {
+    setSelectedAccount(account);
+    setIsDetailOpen(true);
+  };
+
+  const initialValues = useMemo(
+    (): AccountFilterType & { page: number } => ({
+      email: searchParams.get('email') || 'all',
+      role: searchParams.get('role') || 'all',
+      isStudent: searchParams.get('isStudent') || 'all',
+      sortBy: searchParams.get('sortBy') || 'all',
+      page: Number(searchParams.get('page')) || 0,
+    }),
+    [searchParams],
+  );
+
+  const form = useForm<AccountFilterType>({
+    resolver: zodResolver(AccountFilterSchema),
+    defaultValues: {
+      email: initialValues.email,
+      role: initialValues.role,
+      isStudent: initialValues.isStudent,
+      sortBy: initialValues.sortBy,
+    },
+  });
+
+  const { control } = form;
+
+  const filters = useWatch({ control });
+
+  const debouncedEmail = useDebounce(filters.email);
+
+  const currentPage = initialValues.page;
+
+  useEffect(() => {
+    const hasChanged =
+      debouncedEmail !== initialValues.email ||
+      filters.role !== initialValues.role ||
+      filters.isStudent !== initialValues.isStudent ||
+      filters.sortBy !== initialValues.sortBy;
+
+    if (hasChanged) {
+      updateURL(
+        {
+          ...filters,
+          email: debouncedEmail,
+        },
+        0,
+      );
+    }
+  }, [
+    debouncedEmail,
+    filters,
+    filters.role,
+    filters.isStudent,
+    filters.sortBy,
+    initialValues.email,
+    initialValues.role,
+    initialValues.isStudent,
+    initialValues.sortBy,
+    updateURL,
+  ]);
+
+  const handlePageChange = (page: number) => {
+    updateURL(
+      {
+        ...filters,
+        email: debouncedEmail,
+      },
+      page,
+    );
+  };
+
+  const queryParams = {
+    page: currentPage,
+    size: PAGE_SIZE,
+    email: debouncedEmail !== 'all' ? debouncedEmail : undefined,
+    role: filters.role !== 'all' ? (filters.role as UserRoleType) : undefined,
+    isStudent: filters.isStudent !== 'all' ? filters.isStudent === 'true' : undefined,
+    sortBy: filters.sortBy !== 'all' ? (filters.sortBy as AccountSortBy) : undefined,
+  };
+
+  const { data: accountsData, isLoading: isLoadingAccounts } = useGetAccounts(queryParams);
+
+  const accounts = accountsData?.data.accounts;
+  const totalPages = accountsData?.data.totalPages ?? 0;
+
+  return (
+    <div className={cn('bg-background min-h-[calc(100vh-3.5rem)]')}>
+      <main className={cn('container mx-auto px-4 py-8')}>
+        <PageHeader breadcrumb="DATAGSM / Admin" title="계정 관리" />
+
+        <div className={cn('mb-4')}>
+          <AccountFilter control={control} />
+        </div>
+
+        <div className={cn('border-2 border-foreground pixel-shadow')}>
+          <AccountList
+            accounts={accounts}
+            isLoading={isLoadingAccounts}
+            onSelect={handleSelectAccount}
+          />
+        </div>
+
+        <div className={cn('mt-5')}>
+          <CommonPagination
+            isLoading={isLoadingAccounts}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+        </div>
+
+        <AccountDetailDialog
+          account={selectedAccount}
+          open={isDetailOpen}
+          onOpenChange={setIsDetailOpen}
+        />
+      </main>
+    </div>
+  );
+};
+
+export default AccountsPage;

--- a/apps/admin/src/views/accounts/ui/AccountsPage/index.tsx
+++ b/apps/admin/src/views/accounts/ui/AccountsPage/index.tsx
@@ -51,36 +51,47 @@ const AccountsPage = () => {
     },
   });
 
-  const { control } = form;
+  const { control, reset } = form;
 
   const filters = useWatch({ control });
+  const { email, role, isStudent, sortBy } = filters;
 
-  const debouncedEmail = useDebounce(filters.email);
+  const debouncedEmail = useDebounce(email);
 
   const currentPage = initialValues.page;
 
   useEffect(() => {
+    reset({
+      email: initialValues.email,
+      role: initialValues.role,
+      isStudent: initialValues.isStudent,
+      sortBy: initialValues.sortBy,
+    });
+  }, [initialValues, reset]);
+
+  useEffect(() => {
     const hasChanged =
       debouncedEmail !== initialValues.email ||
-      filters.role !== initialValues.role ||
-      filters.isStudent !== initialValues.isStudent ||
-      filters.sortBy !== initialValues.sortBy;
+      role !== initialValues.role ||
+      isStudent !== initialValues.isStudent ||
+      sortBy !== initialValues.sortBy;
 
     if (hasChanged) {
       updateURL(
         {
-          ...filters,
           email: debouncedEmail,
+          role,
+          isStudent,
+          sortBy,
         },
         0,
       );
     }
   }, [
     debouncedEmail,
-    filters,
-    filters.role,
-    filters.isStudent,
-    filters.sortBy,
+    role,
+    isStudent,
+    sortBy,
     initialValues.email,
     initialValues.role,
     initialValues.isStudent,
@@ -91,8 +102,10 @@ const AccountsPage = () => {
   const handlePageChange = (page: number) => {
     updateURL(
       {
-        ...filters,
         email: debouncedEmail,
+        role,
+        isStudent,
+        sortBy,
       },
       page,
     );
@@ -102,9 +115,9 @@ const AccountsPage = () => {
     page: currentPage,
     size: PAGE_SIZE,
     email: debouncedEmail !== 'all' ? debouncedEmail : undefined,
-    role: filters.role !== 'all' ? (filters.role as UserRoleType) : undefined,
-    isStudent: filters.isStudent !== 'all' ? filters.isStudent === 'true' : undefined,
-    sortBy: filters.sortBy !== 'all' ? (filters.sortBy as AccountSortBy) : undefined,
+    role: role !== 'all' ? (role as UserRoleType) : undefined,
+    isStudent: isStudent !== 'all' ? isStudent === 'true' : undefined,
+    sortBy: sortBy !== 'all' ? (sortBy as AccountSortBy) : undefined,
   };
 
   const { data: accountsData, isLoading: isLoadingAccounts } = useGetAccounts(queryParams);

--- a/apps/admin/src/widgets/accounts/index.ts
+++ b/apps/admin/src/widgets/accounts/index.ts
@@ -1,0 +1,4 @@
+export * from './model/useUpdateAccountRole';
+export { default as AccountFilter } from './ui/AccountFilter';
+export { default as AccountList } from './ui/AccountList';
+export { default as AccountDetailDialog } from './ui/AccountDetailDialog';

--- a/apps/admin/src/widgets/accounts/model/useUpdateAccountRole.ts
+++ b/apps/admin/src/widgets/accounts/model/useUpdateAccountRole.ts
@@ -1,0 +1,21 @@
+import { accountQueryKeys, accountUrl, patch } from '@repo/shared/api';
+import { ModifyAccountRoleRequest } from '@repo/shared/types';
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+interface UpdateAccountRoleVariables extends ModifyAccountRoleRequest {
+  accountId: number;
+}
+
+export const useUpdateAccountRole = (
+  options?: Omit<
+    UseMutationOptions<void, AxiosError, UpdateAccountRoleVariables>,
+    'mutationKey' | 'mutationFn'
+  >,
+) =>
+  useMutation({
+    mutationKey: accountQueryKeys.patchAccountRole(),
+    mutationFn: ({ accountId, role }: UpdateAccountRoleVariables) =>
+      patch<void>(accountUrl.patchAccountRole(accountId), { role }),
+    ...options,
+  });

--- a/apps/admin/src/widgets/accounts/ui/AccountDetailDialog/index.tsx
+++ b/apps/admin/src/widgets/accounts/ui/AccountDetailDialog/index.tsx
@@ -91,7 +91,7 @@ const AccountDetailDialog = ({ account, open, onOpenChange }: AccountDetailDialo
                 생성일
               </span>
               <span className={cn('font-mono text-sm')}>
-                {new Date(account.createdAt).toLocaleString('ko-KR')}
+                {new Date(account.createdAt).toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' })}
               </span>
             </div>
           </div>

--- a/apps/admin/src/widgets/accounts/ui/AccountDetailDialog/index.tsx
+++ b/apps/admin/src/widgets/accounts/ui/AccountDetailDialog/index.tsx
@@ -36,10 +36,10 @@ const AccountDetailDialog = ({ account, open, onOpenChange }: AccountDetailDialo
   const [selectedRole, setSelectedRole] = useState<'ADMIN' | 'USER'>('USER');
 
   useEffect(() => {
-    if (account && (account.role === 'ADMIN' || account.role === 'USER')) {
+    if (open && account && (account.role === 'ADMIN' || account.role === 'USER')) {
       setSelectedRole(account.role);
     }
-  }, [account]);
+  }, [account, open]);
 
   const { mutate: updateRole, isPending } = useUpdateAccountRole({
     onSuccess: () => {

--- a/apps/admin/src/widgets/accounts/ui/AccountDetailDialog/index.tsx
+++ b/apps/admin/src/widgets/accounts/ui/AccountDetailDialog/index.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { AccountListItem } from '@repo/shared/types';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@repo/shared/ui';
+import { cn } from '@repo/shared/utils';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { getAccountRoleBadgeStyle, getAccountRoleLabel } from '@/entities/account';
+import { useGetMyAccountId } from '@/entities/signin';
+import { getMajorLabel, getRoleBadgeStyle, getRoleLabel, getSexLabel } from '@/entities/student';
+import { useUpdateAccountRole } from '@/widgets/accounts';
+
+interface AccountDetailDialogProps {
+  account: AccountListItem | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const AccountDetailDialog = ({ account, open, onOpenChange }: AccountDetailDialogProps) => {
+  const queryClient = useQueryClient();
+  const { data: myAccountId } = useGetMyAccountId();
+  const [selectedRole, setSelectedRole] = useState<'ADMIN' | 'USER'>('USER');
+
+  useEffect(() => {
+    if (account && (account.role === 'ADMIN' || account.role === 'USER')) {
+      setSelectedRole(account.role);
+    }
+  }, [account]);
+
+  const { mutate: updateRole, isPending } = useUpdateAccountRole({
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts'] });
+      toast.success('계정 권한이 변경되었습니다.');
+      onOpenChange(false);
+    },
+    onError: (error) => {
+      console.error('계정 권한 변경 실패:', error);
+      toast.error('계정 권한 변경에 실패했습니다.');
+    },
+  });
+
+  if (!account) return null;
+
+  const student = account.student;
+  const isRoleChangeDisabled = account.role === 'ROOT' || account.id === myAccountId;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={cn('max-h-[90vh] max-w-lg overflow-y-auto p-0')}>
+        <DialogHeader className={cn('border-foreground border-b-2 px-6 py-5')}>
+          <DialogTitle className={cn('font-pixel text-[14px] leading-none')}>ACCOUNT DETAIL</DialogTitle>
+        </DialogHeader>
+
+        <div className={cn('space-y-6 px-6 py-6')}>
+          <div className={cn('space-y-2')}>
+            <div className={cn('flex items-center justify-between')}>
+              <span className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}>
+                이메일
+              </span>
+              <span className={cn('font-mono text-sm')}>{account.email}</span>
+            </div>
+            <div className={cn('flex items-center justify-between')}>
+              <span className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}>
+                현재 역할
+              </span>
+              <span
+                className={cn(
+                  'border px-1.5 py-0.5 text-xs font-mono uppercase',
+                  getAccountRoleBadgeStyle(account.role),
+                )}
+              >
+                {getAccountRoleLabel(account.role)}
+              </span>
+            </div>
+            <div className={cn('flex items-center justify-between')}>
+              <span className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}>
+                생성일
+              </span>
+              <span className={cn('font-mono text-sm')}>
+                {new Date(account.createdAt).toLocaleString('ko-KR')}
+              </span>
+            </div>
+          </div>
+
+          <div className={cn('border-foreground/20 border-t pt-4')}>
+            <p className={cn('text-muted-foreground mb-2 font-mono text-xs uppercase tracking-widest')}>
+              연동된 학생 정보
+            </p>
+            {student ? (
+              <div
+                className={cn(
+                  'border-foreground grid grid-cols-2 gap-x-4 gap-y-2 border p-4 font-mono text-sm',
+                )}
+              >
+                <span>이름: {student.name}</span>
+                <span>성별: {getSexLabel(student.sex)}</span>
+                <span>학번: {student.studentNumber}</span>
+                <span>학과: {getMajorLabel(student.major)}</span>
+                <span className={cn('col-span-2')}>
+                  구분:{' '}
+                  <span
+                    className={cn(
+                      'border px-1.5 py-0.5 text-xs font-mono uppercase',
+                      getRoleBadgeStyle(student.role),
+                    )}
+                  >
+                    {getRoleLabel(student.role)}
+                  </span>
+                </span>
+                <span>기숙사: {student.dormitoryRoom ? `${student.dormitoryRoom}호` : '없음'}</span>
+                <span>전공 동아리: {student.majorClub?.name ?? '없음'}</span>
+                <span>자율 동아리: {student.autonomousClub?.name ?? '없음'}</span>
+              </div>
+            ) : (
+              <div
+                className={cn(
+                  'border-foreground/25 text-muted-foreground border border-dashed p-4 text-center font-mono text-sm',
+                )}
+              >
+                연동된 학생 정보가 없습니다.
+              </div>
+            )}
+          </div>
+
+          <div className={cn('border-foreground/20 border-t pt-4')}>
+            <p className={cn('text-muted-foreground mb-2 font-mono text-xs uppercase tracking-widest')}>
+              권한 변경
+            </p>
+            {isRoleChangeDisabled ? (
+              <p className={cn('text-muted-foreground font-mono text-xs')}>
+                {account.role === 'ROOT'
+                  ? '루트 계정의 권한은 변경할 수 없습니다.'
+                  : '본인의 권한은 변경할 수 없습니다.'}
+              </p>
+            ) : (
+              <div className={cn('flex items-center gap-2')}>
+                <Select
+                  value={selectedRole}
+                  onValueChange={(v) => setSelectedRole(v as 'ADMIN' | 'USER')}
+                >
+                  <SelectTrigger className={cn('border-foreground w-32 rounded-none')}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="USER">유저</SelectItem>
+                    <SelectItem value="ADMIN">어드민</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Button
+                  type="button"
+                  disabled={isPending || selectedRole === account.role}
+                  onClick={() => updateRole({ accountId: account.id, role: selectedRole })}
+                >
+                  {isPending ? '변경 중...' : '변경'}
+                </Button>
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AccountDetailDialog;

--- a/apps/admin/src/widgets/accounts/ui/AccountFilter/index.tsx
+++ b/apps/admin/src/widgets/accounts/ui/AccountFilter/index.tsx
@@ -1,0 +1,110 @@
+import {
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@repo/shared/ui';
+import { cn } from '@repo/shared/utils';
+import { Search } from 'lucide-react';
+import { Control, Controller } from 'react-hook-form';
+
+import { AccountFilterType } from '@/entities/account';
+
+interface AccountFilterProps {
+  control: Control<AccountFilterType>;
+}
+
+const AccountFilter = ({ control }: AccountFilterProps) => {
+  return (
+    <div className={cn('mt-4 flex flex-wrap items-center gap-4')}>
+      <div className={cn('relative flex-1')}>
+        <Search
+          className={cn('text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2')}
+        />
+        <Controller
+          control={control}
+          name="email"
+          render={({ field }) => (
+            <Input
+              {...field}
+              placeholder="이메일로 검색"
+              className={cn('pl-9 rounded-none border-foreground font-mono')}
+              onChange={(e) => {
+                field.onChange(e.target.value || 'all');
+              }}
+              value={field.value === 'all' ? '' : field.value}
+            />
+          )}
+        />
+      </div>
+
+      <div className={cn('flex items-center gap-2')}>
+        <Label className={cn('text-xs uppercase tracking-widest text-muted-foreground font-mono')}>역할:</Label>
+        <Controller
+          control={control}
+          name="role"
+          render={({ field }) => (
+            <Select value={field.value} onValueChange={field.onChange}>
+              <SelectTrigger className={cn('w-28 rounded-none border-foreground')}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">전체</SelectItem>
+                <SelectItem value="USER">유저</SelectItem>
+                <SelectItem value="ADMIN">어드민</SelectItem>
+                <SelectItem value="ROOT">루트</SelectItem>
+              </SelectContent>
+            </Select>
+          )}
+        />
+      </div>
+
+      <div className={cn('flex items-center gap-2')}>
+        <Label className={cn('text-xs uppercase tracking-widest text-muted-foreground font-mono')}>학생 연동:</Label>
+        <Controller
+          control={control}
+          name="isStudent"
+          render={({ field }) => (
+            <Select value={field.value} onValueChange={field.onChange}>
+              <SelectTrigger className={cn('w-28 rounded-none border-foreground')}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">전체</SelectItem>
+                <SelectItem value="true">연동됨</SelectItem>
+                <SelectItem value="false">미연동</SelectItem>
+              </SelectContent>
+            </Select>
+          )}
+        />
+      </div>
+
+      <div className={cn('flex items-center gap-2')}>
+        <Label className={cn('text-xs uppercase tracking-widest text-muted-foreground font-mono')}>정렬 기준:</Label>
+        <Controller
+          control={control}
+          name="sortBy"
+          render={({ field }) => (
+            <Select value={field.value} onValueChange={field.onChange}>
+              <SelectTrigger className={cn('w-32 rounded-none border-foreground')}>
+                <SelectValue placeholder="기본" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">기본</SelectItem>
+                <SelectItem value="ID">ID</SelectItem>
+                <SelectItem value="EMAIL">이메일</SelectItem>
+                <SelectItem value="ROLE">역할</SelectItem>
+                <SelectItem value="CREATED_AT">생성일</SelectItem>
+              </SelectContent>
+            </Select>
+          )}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default AccountFilter;

--- a/apps/admin/src/widgets/accounts/ui/AccountList/index.tsx
+++ b/apps/admin/src/widgets/accounts/ui/AccountList/index.tsx
@@ -1,5 +1,6 @@
 import { AccountListItem } from '@repo/shared/types';
 import {
+  PixelIconButton,
   Skeleton,
   Table,
   TableBody,
@@ -9,6 +10,7 @@ import {
   TableRow,
 } from '@repo/shared/ui';
 import { cn } from '@repo/shared/utils';
+import { Pencil } from 'lucide-react';
 
 import { getAccountRoleBadgeStyle, getAccountRoleLabel } from '@/entities/account';
 
@@ -28,6 +30,7 @@ const AccountList = ({ accounts, isLoading, onSelect }: AccountListProps) => {
           <TableHead>역할</TableHead>
           <TableHead>학생 연동</TableHead>
           <TableHead>생성일</TableHead>
+          <TableHead className={cn('w-30')}>작업</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -49,14 +52,13 @@ const AccountList = ({ accounts, isLoading, onSelect }: AccountListProps) => {
                 <TableCell>
                   <Skeleton className={cn('h-4 w-24')} />
                 </TableCell>
+                <TableCell>
+                  <Skeleton className={cn('h-8 w-8')} />
+                </TableCell>
               </TableRow>
             ))
           : accounts?.map((account) => (
-              <TableRow
-                key={account.id}
-                className={cn('cursor-pointer')}
-                onClick={() => onSelect?.(account)}
-              >
+              <TableRow key={account.id}>
                 <TableCell>{account.id}</TableCell>
                 <TableCell>{account.email}</TableCell>
                 <TableCell>
@@ -72,6 +74,11 @@ const AccountList = ({ accounts, isLoading, onSelect }: AccountListProps) => {
                 <TableCell>{account.isStudent ? '연동됨' : '미연동'}</TableCell>
                 <TableCell>
                   {new Date(account.createdAt).toLocaleDateString('ko-KR', { timeZone: 'Asia/Seoul' })}
+                </TableCell>
+                <TableCell>
+                  <PixelIconButton onClick={() => onSelect?.(account)}>
+                    <Pencil className={cn('h-3.5 w-3.5')} />
+                  </PixelIconButton>
                 </TableCell>
               </TableRow>
             ))}

--- a/apps/admin/src/widgets/accounts/ui/AccountList/index.tsx
+++ b/apps/admin/src/widgets/accounts/ui/AccountList/index.tsx
@@ -1,0 +1,81 @@
+import { AccountListItem } from '@repo/shared/types';
+import {
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@repo/shared/ui';
+import { cn } from '@repo/shared/utils';
+
+import { getAccountRoleBadgeStyle, getAccountRoleLabel } from '@/entities/account';
+
+interface AccountListProps {
+  accounts?: AccountListItem[];
+  isLoading?: boolean;
+  onSelect?: (account: AccountListItem) => void;
+}
+
+const AccountList = ({ accounts, isLoading, onSelect }: AccountListProps) => {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>ID</TableHead>
+          <TableHead>이메일</TableHead>
+          <TableHead>역할</TableHead>
+          <TableHead>학생 연동</TableHead>
+          <TableHead>생성일</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {isLoading
+          ? Array.from({ length: 10 }).map((_, index) => (
+              <TableRow key={index}>
+                <TableCell>
+                  <Skeleton className={cn('h-4 w-8')} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className={cn('h-4 w-40')} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className={cn('h-5 w-16')} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className={cn('h-4 w-12')} />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className={cn('h-4 w-24')} />
+                </TableCell>
+              </TableRow>
+            ))
+          : accounts?.map((account) => (
+              <TableRow
+                key={account.id}
+                className={cn('cursor-pointer')}
+                onClick={() => onSelect?.(account)}
+              >
+                <TableCell>{account.id}</TableCell>
+                <TableCell>{account.email}</TableCell>
+                <TableCell>
+                  <span
+                    className={cn(
+                      'border px-1.5 py-0.5 text-xs font-mono uppercase',
+                      getAccountRoleBadgeStyle(account.role),
+                    )}
+                  >
+                    {getAccountRoleLabel(account.role)}
+                  </span>
+                </TableCell>
+                <TableCell>{account.isStudent ? '연동됨' : '미연동'}</TableCell>
+                <TableCell>{new Date(account.createdAt).toLocaleDateString('ko-KR')}</TableCell>
+              </TableRow>
+            ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+export default AccountList;

--- a/apps/admin/src/widgets/accounts/ui/AccountList/index.tsx
+++ b/apps/admin/src/widgets/accounts/ui/AccountList/index.tsx
@@ -70,7 +70,9 @@ const AccountList = ({ accounts, isLoading, onSelect }: AccountListProps) => {
                   </span>
                 </TableCell>
                 <TableCell>{account.isStudent ? '연동됨' : '미연동'}</TableCell>
-                <TableCell>{new Date(account.createdAt).toLocaleDateString('ko-KR')}</TableCell>
+                <TableCell>
+                  {new Date(account.createdAt).toLocaleDateString('ko-KR', { timeZone: 'Asia/Seoul' })}
+                </TableCell>
               </TableRow>
             ))}
       </TableBody>

--- a/packages/shared/src/api/apiUrls.ts
+++ b/packages/shared/src/api/apiUrls.ts
@@ -1,5 +1,6 @@
 import { ClubType, StudentRole, StudentSex } from '@repo/shared/types';
 
+import { AccountSortBy } from '../types/account';
 import { UserRoleType } from '../types/userRole';
 
 export const studentUrl = {
@@ -195,6 +196,27 @@ export const accountUrl = {
   postPasswordReset: () => '/v1/accounts/password-resets', // 비밀번호 재설정 요청 (이메일 발송)
   postPasswordResetVerification: () => '/v1/accounts/password-resets/verification', // 비밀번호 재설정 코드 검증
   putPassword: () => '/v1/accounts/password', // 비밀번호 변경 (인증된 사용자)
+  getAccounts: (params: {
+    page?: number;
+    size?: number;
+    email?: string;
+    role?: UserRoleType;
+    isStudent?: boolean;
+    sortBy?: AccountSortBy;
+  }) => {
+    const urlParams = new URLSearchParams();
+
+    if (params.page !== undefined) urlParams.append('page', params.page.toString());
+    if (params.size !== undefined) urlParams.append('size', params.size.toString());
+    if (params.email) urlParams.append('email', params.email);
+    if (params.role !== undefined) urlParams.append('role', params.role);
+    if (params.isStudent !== undefined) urlParams.append('isStudent', params.isStudent.toString());
+    if (params.sortBy !== undefined) urlParams.append('sortBy', params.sortBy);
+
+    const queryString = urlParams.toString();
+    return queryString ? `/v1/accounts?${queryString}` : '/v1/accounts';
+  },
+  patchAccountRole: (accountId: number) => `/v1/accounts/${accountId}/role`,
 } as const;
 
 export const oauthUrl = {

--- a/packages/shared/src/api/queryKeys.ts
+++ b/packages/shared/src/api/queryKeys.ts
@@ -131,6 +131,15 @@ export const accountQueryKeys = {
   postPasswordReset: () => ['accounts', 'password-resets'] as const,
   postPasswordResetVerification: () => ['accounts', 'password-resets', 'verification'] as const,
   putPassword: () => ['accounts', 'password', 'update'] as const,
+  getAccounts: (params: {
+    page?: number;
+    size?: number;
+    email?: string;
+    role?: string;
+    isStudent?: boolean;
+    sortBy?: string;
+  }) => ['accounts', 'list', params] as const,
+  patchAccountRole: () => ['accounts', 'role', 'update'] as const,
 } as const;
 
 export const oauthQueryKeys = {

--- a/packages/shared/src/constants/navigation.ts
+++ b/packages/shared/src/constants/navigation.ts
@@ -14,6 +14,7 @@ export const NAV_LINKS = {
   ],
   admin: [
     { href: '/students', label: '학생' },
+    { href: '/accounts', label: '계정' },
     { href: '/clubs', label: '동아리' },
     { href: '/projects', label: '프로젝트' },
     { href: '/api-keys', label: 'API 키' },

--- a/packages/shared/src/types/account.ts
+++ b/packages/shared/src/types/account.ts
@@ -1,0 +1,27 @@
+import { ApiResponse } from './base';
+import { Student } from './student';
+import { UserRoleType } from './userRole';
+
+export type AccountSortBy = 'ID' | 'EMAIL' | 'ROLE' | 'CREATED_AT';
+
+export interface AccountListItem {
+  id: number;
+  email: string;
+  role: UserRoleType;
+  isStudent: boolean;
+  student: Student | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AccountListData {
+  totalPages: number;
+  totalElements: number;
+  accounts: AccountListItem[];
+}
+
+export type AccountListResponse = ApiResponse<AccountListData>;
+
+export interface ModifyAccountRoleRequest {
+  role: Extract<UserRoleType, 'ADMIN' | 'USER'>;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './account';
 export * from './auth';
 export * from './base';
 export * from './club';


### PR DESCRIPTION
## 개요 💡

어드민 페이지에서 계정(Account)을 관리할 수 있는 기능이 없어 계정 정보 확인이나 권한 변경 시 직접 DB에 접근해야 하는 번거로움이 있었습니다. 서버에 추가된 계정 관리 API(datagsm-server#396)를 기반으로, 학생 관리 페이지와 동일한 구조/컨벤션으로 계정 관리 페이지를 구현했습니다.

## 작업내용 ⌨️

- `GET /v1/accounts` 연동: 이메일/역할(USER, ADMIN, ROOT)/학생 연동 여부 필터, 페이지네이션, 정렬 기준 지원
- 계정 목록에서 행 클릭 시 상세 다이얼로그 오픈, 연동된 학생 정보를 함께 표시 (학생 계정이 아니면 "연동된 학생 정보가 없습니다" 표시)
- `PATCH /v1/accounts/{accountId}/role` 연동: 계정 권한(USER ↔ ADMIN) 변경 기능 추가
  - 본인 계정 및 ROOT 계정은 프론트에서도 변경 UI를 비활성화 처리 (서버에서도 403으로 막고 있음)
- 어드민 상단 네비게이션에 "계정" 메뉴 추가
- `packages/shared`에 계정 관리용 타입(`AccountListItem`, `AccountListResponse` 등), API URL/쿼리키(`accountUrl.getAccounts`, `accountUrl.patchAccountRole`) 추가

## 스크린샷/동영상 📸


https://github.com/user-attachments/assets/536464f4-0e0d-4074-a49d-1bb15e93fc62



## 관련 이슈 🚨

- closes #192
- 참고 서버 PR: [datagsm-server#396](https://github.com/themoment-team/datagsm-server/pull/396)

## 리뷰 요청사항 👀

- 학생 관리 페이지 구조를 그대로 재사용했는데, 계정 관리 특성상 다르게 가져가야 할 부분이 있는지 확인 부탁드립니다.
- 상세 다이얼로그에서 목록 응답에 이미 포함된 학생 정보를 재사용하고 별도로 단건 조회 API(`GET /v1/accounts/{accountId}`)는 호출하지 않도록 했는데, 이 판단이 맞는지 검토 부탁드립니다.
- 권한 변경 시 본인/ROOT 계정 여부를 프론트에서도 막아뒀는데, 이 가드가 UX상 충분한지 확인 부탁드립니다.
