### PR TITLE
[docs] OAuth 기본 권한 범위를 `datagsm:self_read`로 정정

### DIFF
--- a/apps/docs/src/app/oauth/http/authorize/page.mdx
+++ b/apps/docs/src/app/oauth/http/authorize/page.mdx
@@ -44,15 +44,17 @@ OAuth 인증 흐름의 진입점입니다. 클라이언트가 사용자를 이 �
 | `state`                 | `String` | 선택 (권장)   | CSRF 공격 방지용 임의 문자열. 콜백 시 그대로 반환됨                  | `randomString123`                             |
 | `code_challenge`        | `String` | 선택 (PKCE) | PKCE Code Verifier를 SHA-256 해싱 후 Base64URL 인코딩한 값 | `E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM` |
 | `code_challenge_method` | `String` | 선택 (PKCE) | Challenge 생성 방법 (`S256` 권장, `plain` 지원)           | `S256`                                        |
-| `scope`                 | `String` | 선택        | 요청할 OAuth Scope 목록 (공백으로 구분). 미지정 시 기본 사용자 정보 조회 흐름으로 처리 | self:read |
+| `scope`                 | `String` | 선택        | 요청할 OAuth Scope 목록 (공백으로 구분). 미지정 시 클라이언트에 등록된 권한 범위 전체가 부여됨 | `{applicationId}:{scopeName}` |
 
 ### Scope 사용 방식
 
-DataGSM OAuth의 기본 사용자 정보 조회 권한 범위는 `self:read`입니다. 이 권한으로 [사용자 데이터 조회](/oauth/http/userinfo) 엔드포인트에서 사용자 기본 정보와 학생 상세 데이터를 조회할 수 있습니다.
+**모든 권한 범위는 `{applicationId}:{scopeName}` 형식입니다.** DataGSM 기본 권한 범위도 예외가 아니며, 사용자 정보 조회 권한은 `datagsm:self_read`입니다. 이 권한이 있어야 [사용자 데이터 조회](/oauth/http/userinfo) 엔드포인트에서 사용자 기본 정보와 학생 상세 데이터를 조회할 수 있습니다.
 
-신규 OAuth 연동에서 사용자 본인 정보만 필요하다면 `scope` 파라미터를 생략할 수 있습니다. 명시적으로 표현하고 싶다면 `scope=self:read`를 전달하세요.
+**`scope` 파라미터는 생략하는 것을 권장합니다.** 생략하면 클라이언트에 등록된 권한 범위 전체가 부여되므로, Application ID를 애플리케이션 코드에 넣지 않아도 됩니다.
 
-서드파티 애플리케이션이 직접 정의한 권한 범위를 요청해야 할 때만 해당 애플리케이션의 Application ID를 앞에 붙인 `{applicationId}:{scopeName}` 형식을 사용합니다. 여러 권한 범위를 요청하는 경우 공백으로 구분하며, URL에서는 공백을 `%20`으로 인코딩합니다.
+명시적으로 전달할 경우 **클라이언트에 등록된 권한 범위의 부분집합**이어야 합니다. 등록되지 않은 값이 하나라도 포함되면 `400 invalid_scope`로 거부됩니다. 정확한 문자열은 클라이언트 등록 화면에서 확인할 수 있습니다.
+
+여러 권한 범위를 요청하는 경우 공백으로 구분하며, URL에서는 공백을 `%20`으로 인코딩합니다.
 
 ### 응답
 
@@ -113,7 +115,7 @@ const params = new URLSearchParams({
   redirect_uri: 'https://your-app.com/callback',
   response_type: 'code',
   state,
-  scope: 'self:read',
+  scope: 'datagsm:self_read',
   code_challenge: codeChallenge,
   code_challenge_method: 'S256',
 });

--- a/apps/docs/src/app/oauth/http/page.mdx
+++ b/apps/docs/src/app/oauth/http/page.mdx
@@ -56,26 +56,26 @@ Content-Type: application/json
   "token_type": "Bearer",
   "expires_in": 3600,
   "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-  "scope": "self:read"
+  "scope": "datagsm:self_read"
 }
 ```
 
-| 필드              | 타입       | 설명                                     |
-|-----------------|----------|----------------------------------------|
-| `access_token`  | `String` | JWT 형식의 Access Token (1시간 유효)          |
-| `token_type`    | `String` | 토큰 타입 (`Bearer` 고정)                    |
+| 필드            | 타입     | 설명                                             |
+|-----------------|----------|--------------------------------------------------|
+| `access_token`  | `String` | JWT 형식의 Access Token (1시간 유효)             |
+| `token_type`    | `String` | 토큰 타입 (`Bearer` 고정)                        |
 | `expires_in`    | `Int`    | Access Token의 만료 시간 (초 단위, 3600 = 1시간) |
-| `refresh_token` | `String` | Refresh Token (30일 유효)                 |
-| `scope`         | `String` | 발급된 권한 범위 (공백으로 구분)                    |
+| `refresh_token` | `String` | Refresh Token (30일 유효)                        |
+| `scope`         | `String` | 발급된 권한 범위 (공백으로 구분)                 |
 
 ### 사용 가능한 엔드포인트
 
-| 엔드포인트                 | 메서드    | 설명                                               | 기술 문서                                       |
-|-----------------------|--------|--------------------------------------------------|------------------------------------------|
-| `/v1/oauth/authorize` | `GET`  | OAuth 인증 흐름 시작 (사용자를 로그인 페이지로 리다이렉트)             | [상세 기술 문서](/oauth/http/authorize)      |
+| 엔드포인트            | 메서드 | 설명                                                         | 기술 문서                                    |
+|-----------------------|--------|--------------------------------------------------------------|----------------------------------------------|
+| `/v1/oauth/authorize` | `GET`  | OAuth 인증 흐름 시작 (사용자를 로그인 페이지로 리다이렉트)   | [상세 기술 문서](/oauth/http/authorize)      |
 | `/v1/oauth/token`     | `POST` | Authorization Code를 Access Token으로 교환 (통합 엔드포인트) | [상세 기술 문서](/oauth/http/token-exchange) |
 | `/v1/oauth/token`     | `POST` | Refresh Token으로 새 Access Token 발급 (통합 엔드포인트)     | [상세 기술 문서](/oauth/http/token-refresh)  |
-| `/userinfo`           | `GET`  | Access Token으로 사용자 데이터 조회                         | [상세 기술 문서](/oauth/http/userinfo)       |
+| `/userinfo`           | `GET`  | Access Token으로 사용자 데이터 조회                          | [상세 기술 문서](/oauth/http/userinfo)       |
 
 ### 에러 처리
 

--- a/apps/docs/src/app/oauth/http/token-exchange/page.mdx
+++ b/apps/docs/src/app/oauth/http/token-exchange/page.mdx
@@ -86,24 +86,24 @@ Authorization Code를 Access Token과 Refresh Token으로 교환합니다. 보�
   "token_type": "Bearer",
   "expires_in": 3600,
   "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-  "scope": "self:read"
+  "scope": "datagsm:self_read"
 }
 ```
 
-| 필드 | 타입 | 설명 |
-| --- | --- | --- |
-| `access_token` | `String` | JWT 형식의 Access Token (1시간 유효) |
-| `token_type` | `String` | 토큰 타입 (`Bearer` 고정) |
-| `expires_in` | `Int` | Access Token의 만료 시간 (초 단위, 3600 = 1시간) |
-| `refresh_token` | `String` | Refresh Token (30일 유효) |
-| `scope` | `String` | 발급된 권한 범위 (공백으로 구분) |
+| 필드            | 타입     | 설명                                             |
+|-----------------|----------|--------------------------------------------------|
+| `access_token`  | `String` | JWT 형식의 Access Token (1시간 유효)             |
+| `token_type`    | `String` | 토큰 타입 (`Bearer` 고정)                        |
+| `expires_in`    | `Int`    | Access Token의 만료 시간 (초 단위, 3600 = 1시간) |
+| `refresh_token` | `String` | Refresh Token (30일 유효)                        |
+| `scope`         | `String` | 발급된 권한 범위 (공백으로 구분)                 |
 
 ### 오류 응답
 
-| 상태 코드 | 설명 | 원인 |
-| --- | --- | --- |
-| `400 Bad Request` | 잘못된 요청 | 필수 파라미터 누락, 잘못된 형식, Authorization Code가 만료되었거나 유효하지 않음 |
-| `401 Unauthorized` | 인증 실패 | Client ID가 존재하지 않거나 Client Secret이 올바르지 않음 |
+| 상태 코드          | 설명        | 원인                                                                             |
+|--------------------|-------------|----------------------------------------------------------------------------------|
+| `400 Bad Request`  | 잘못된 요청 | 필수 파라미터 누락, 잘못된 형식, Authorization Code가 만료되었거나 유효하지 않음 |
+| `401 Unauthorized` | 인증 실패   | Client ID가 존재하지 않거나 Client Secret이 올바르지 않음                        |
 
 ### 요청 예시
 
@@ -131,7 +131,7 @@ curl -X POST "https://oauth.authorization.datagsm.kr/v1/oauth/token" \
   "token_type": "Bearer",
   "expires_in": 3600,
   "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
-  "scope": "self:read"
+  "scope": "datagsm:self_read"
 }
 ```
 

--- a/apps/docs/src/app/oauth/http/token-refresh/page.mdx
+++ b/apps/docs/src/app/oauth/http/token-refresh/page.mdx
@@ -59,7 +59,7 @@ Refresh Token은 **30일의 유효기간**을 가지며, 갱신 시 새로운 Re
   "token_type": "Bearer",
   "expires_in": 3600,
   "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-  "scope": "self:read"
+  "scope": "datagsm:self_read"
 }
 ```
 
@@ -102,7 +102,7 @@ curl -X POST "https://oauth.authorization.datagsm.kr/v1/oauth/token" \
   "token_type": "Bearer",
   "expires_in": 3600,
   "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
-  "scope": "self:read"
+  "scope": "datagsm:self_read"
 }
 ```
 

--- a/apps/docs/src/app/oauth/page.mdx
+++ b/apps/docs/src/app/oauth/page.mdx
@@ -77,13 +77,13 @@ Access Token 만료 시 새로운 Access Token을 발급받기 위한 토큰입�
 
 ### 기본 권한 범위
 
-DataGSM OAuth는 사용자 기본 정보를 조회하기 위한 기본 권한 범위로 `self:read`를 사용합니다.
+DataGSM OAuth는 사용자 기본 정보를 조회하기 위한 기본 권한 범위로 `datagsm:self_read`를 사용합니다. **모든 권한 범위는 `{applicationId}:{scopeName}` 형식이며, 기본 권한 범위도 예외가 아닙니다.**
 
-`self:read` 권한 범위가 포함된 Access Token으로 [사용자 데이터 조회](/oauth/http/userinfo) 엔드포인트를 호출하면 사용자의 기본 데이터와 학생 상세 데이터를 조회할 수 있습니다.
+이 권한 범위가 포함된 Access Token으로 [사용자 데이터 조회](/oauth/http/userinfo) 엔드포인트를 호출하면 사용자의 기본 데이터와 학생 상세 데이터를 조회할 수 있습니다.
 
-OAuth 인증 요청에서 `scope` 파라미터를 생략하면 별도의 서드파티 권한 범위를 요청하지 않는 기본 사용자 정보 조회 흐름으로 처리됩니다. 신규 연동에서 사용자 본인 정보만 필요하다면 `scope`를 생략하거나 명시적으로 `scope=self:read`를 전달할 수 있습니다.
+OAuth 인증 요청에서 `scope` 파라미터를 **생략하는 것을 권장합니다.** 생략하면 클라이언트에 등록된 권한 범위 전체가 부여되므로, Application ID를 애플리케이션 코드에 넣지 않아도 됩니다.
 
-외부 애플리케이션이 직접 정의한 추가 권한 범위가 필요한 경우에만 `{applicationId}:{scopeName}` 형식의 서드파티 권한 범위를 `scope` 파라미터에 포함합니다. 자세한 내용은 [서드파티 권한 범위](/oauth/thirdparty-scope)를 참고하세요.
+명시적으로 전달할 경우 클라이언트에 등록된 권한 범위의 부분집합이어야 하며, 등록되지 않은 값이 포함되면 `400 invalid_scope`로 거부됩니다. 자세한 내용은 [서드파티 권한 범위](/oauth/thirdparty-scope)를 참고하세요.
 
 ### 인증 플로우
 

--- a/apps/docs/src/app/oauth/thirdparty-scope/page.mdx
+++ b/apps/docs/src/app/oauth/thirdparty-scope/page.mdx
@@ -28,9 +28,7 @@ export const metadata = createDocsPageMetadata({ title: "서드파티 권한 범
 
 ### 권한 범위 형식
 
-DataGSM OAuth의 기본 사용자 정보 조회 권한 범위는 `self:read`입니다. 이 기본 scope는 DataGSM 사용자 본인 정보를 조회하기 위한 권한이며, 서드파티 Application ID를 붙여서 사용하지 않습니다.
-
-서드파티 권한 범위는 `{applicationId}:{scopeName}` 형식의 문자열로 표현됩니다.
+**모든 권한 범위는 `{applicationId}:{scopeName}` 형식의 문자열입니다.** DataGSM 기본 권한 범위도 예외가 아닙니다.
 
 ```
 a1b2c3d4-e5f6-7890-abcd-ef1234567890:profile
@@ -38,25 +36,25 @@ a1b2c3d4-e5f6-7890-abcd-ef1234567890:profile
 
 위 예시에서 `a1b2c3d4-e5f6-7890-abcd-ef1234567890`은 Application ID이고, `profile`은 해당 Application에서 정의한 권한 범위 이름입니다.
 
-| 구분 | 형식 | 사용 목적 |
-| --- | --- | --- |
-| DataGSM 기본 scope | `self:read` | DataGSM 사용자 기본 정보 및 학생 상세 데이터 조회 |
-| 서드파티 scope | `{applicationId}:{scopeName}` | 외부 애플리케이션이 직접 정의한 권한 범위 요청 |
+| 구분               | 형식                               | 사용 목적                                         |
+|--------------------|------------------------------------|---------------------------------------------------|
+| DataGSM 기본 scope | `datagsm:self_read` | DataGSM 사용자 기본 정보 및 학생 상세 데이터 조회 |
+| 서드파티 scope     | `{applicationId}:{scopeName}`      | 외부 애플리케이션이 직접 정의한 권한 범위 요청    |
 
 #### scopeName 제약 조건
 
-| 항목         | 규칙                                                       |
-|------------|----------------------------------------------------------|
-| **허용 문자**  | 소문자 영문(`a-z`), 숫자(`0-9`), 언더스코어(`_`), 하이픈(`-`)          |
-| **최대 길이**  | 100자                                                     |
-| **금지 문자**  | 콜론(`:`) — 권한 범위 형식의 구분자로 사용되므로 scopeName에 포함할 수 없습니다     |
-| **유일성**    | 동일 Application 내에서 scopeName은 고유해야 합니다                    |
+| 항목          | 규칙                                                                            |
+|---------------|---------------------------------------------------------------------------------|
+| **허용 문자** | 소문자 영문(`a-z`), 숫자(`0-9`), 언더스코어(`_`), 하이픈(`-`)                   |
+| **최대 길이** | 100자                                                                           |
+| **금지 문자** | 콜론(`:`) — 권한 범위 형식의 구분자로 사용되므로 scopeName에 포함할 수 없습니다 |
+| **유일성**    | 동일 Application 내에서 scopeName은 고유해야 합니다                             |
 
 #### description 제약 조건
 
-| 항목        | 규칙       |
-|-----------|----------|
-| **최대 길이** | 255자     |
+| 항목          | 규칙              |
+|---------------|-------------------|
+| **최대 길이** | 255자             |
 | **필수 여부** | 필수 (빈 값 불가) |
 
 ### 권한 범위 생명주기
@@ -104,8 +102,8 @@ GET /v1/oauth/authorize?client_id=your-client-id&redirect_uri=https://your-app.c
 GET /v1/oauth/authorize?client_id=your-client-id&redirect_uri=https://your-app.com/callback&scope=a1b2c3d4:profile%20a1b2c3d4:email
 ```
 
-- DataGSM 사용자 본인 정보만 필요하다면 `scope` 파라미터를 생략하거나 `self:read`를 전달합니다.
-- 서드파티 권한 범위를 요청할 때는 `{applicationId}:{scopeName}` 형식을 사용합니다.
+- DataGSM 사용자 본인 정보만 필요하다면 `scope` 파라미터를 생략하는 것을 권장합니다. 클라이언트에 등록된 권한 범위 전체가 부여됩니다.
+- 권한 범위를 명시할 때는 DataGSM 기본 권한 범위를 포함해 모두 `{applicationId}:{scopeName}` 형식을 사용합니다.
 - 요청한 권한범위가  Client의 허용 목록에 포함되지 않으면 `400 Bad Request` 오류가 발생합니다.
 - 권한 범위 정보는 Authorization Code → Access Token까지 전파되며, Refresh Token 갱신 시에도 원래 권한 범위가 유지됩니다.
 
@@ -145,13 +143,13 @@ GET /v1/oauth/authorize?client_id=your-client-id&redirect_uri=https://your-app.c
 
 ### 오류 응답
 
-| 상태 코드              | 설명                     | 원인                                                  |
-|--------------------|------------------------|-----------------------------------------------------|
-| `400 Bad Request`  | 잘못된 요청                 | 검증 실패 (scopeName 형식 불일치, 필수 필드 누락 등)                |
-| `401 Unauthorized` | 인증되지 않은 요청             | 유효하지 않은 세션                                          |
-| `403 Forbidden`    | 권한이 없는 요청              | Application 소유자가 아니거나 관리자 권한 없음                      |
-| `404 Not Found`    | 리소스를 찾을 수 없음           | 존재하지 않는 Application ID 또는 권한 범위 ID                   |
-| `409 Conflict`     | 리소스 충돌                 | 동일 Application 내에 이미 같은 scopeName이 존재                |
+| 상태 코드          | 설명                  | 원인                                                 |
+|--------------------|-----------------------|------------------------------------------------------|
+| `400 Bad Request`  | 잘못된 요청           | 검증 실패 (scopeName 형식 불일치, 필수 필드 누락 등) |
+| `401 Unauthorized` | 인증되지 않은 요청    | 유효하지 않은 세션                                   |
+| `403 Forbidden`    | 권한이 없는 요청      | Application 소유자가 아니거나 관리자 권한 없음       |
+| `404 Not Found`    | 리소스를 찾을 수 없음 | 존재하지 않는 Application ID 또는 권한 범위 ID       |
+| `409 Conflict`     | 리소스 충돌           | 동일 Application 내에 이미 같은 scopeName이 존재     |
 
 ### 주의사항
 


### PR DESCRIPTION
## 개요 💡

기술문서에 안내된 DataGSM 기본 권한 범위 `self:read` 가 실제 서버 구현과 달라, 문서대로 요청하면 인증이 시작조차 되지 않습니다.

```
GET /v1/oauth/authorize?...&scope=self:read
→ 400 {"error":"invalid_scope","error_description":"클라이언트에 허용되지 않은 권한 범위가 포함되어 있습니다."}
```

`OAuthScope` 는 모든 권한 범위를 `{applicationId}:{scopeName}` 으로 다루므로 `self:read` 는 applicationId `self` / scopeName `read` 로 해석됩니다. 그런 Application 이 없어 어떤 클라이언트의 허용 목록에도 포함될 수 없고, `StartOauthAuthorizeFlowServiceImpl.resolveScopes` 의 부분집합 검사에서 항상 걸립니다.

실제 기본 권한 범위는 **`datagsm:self_read`** 입니다. `datagsm-oauth-userinfo` 의 `SecurityConfig` 가 `/userinfo` 에 요구하는 권한이 `OAuthScope.authorityOf(datagsmApplicationId, "self_read")` 이기 때문입니다.

같은 클라이언트로 확인한 결과입니다.

| scope | 응답 |
| --- | --- |
| `datagsm:self_read` | 302 (정상) |
| `self:read` | 400 invalid_scope |

문서에 "기본 scope 는 서드파티 Application ID 를 붙이지 않는다" 고 적혀 있으나 구현상 예외는 없습니다. 또한 같은 문서가 scopeName 에 콜론을 금지하고 있어, `self:read` 표기는 그 규칙과도 모순됩니다.

## 작업내용 ⌨️

- 기본 권한 범위 표기를 `self:read` → `datagsm:self_read` 로 정정
- "기본 scope 는 Application ID 를 붙이지 않는다" 는 서술 삭제. 모든 권한 범위가 `{applicationId}:{scopeName}` 형식임을 명시
- `scope` 파라미터는 **생략을 권장**하도록 변경. 생략 시 클라이언트에 등록된 권한 범위 전체가 부여되므로 Application ID 를 애플리케이션 코드에 넣지 않아도 됩니다
- 명시적으로 전달할 경우 클라이언트 등록분의 부분집합이어야 하며, 아니면 `400 invalid_scope` 로 거부된다는 규칙 추가
- 토큰 발급·갱신 응답 예시의 `scope` 값을 실제 형식으로 수정

수정한 문서

- `oauth/page.mdx`
- `oauth/thirdparty-scope/page.mdx`
- `oauth/http/page.mdx`
- `oauth/http/authorize/page.mdx`
- `oauth/http/token-exchange/page.mdx`
- `oauth/http/token-refresh/page.mdx`

## 관련 이슈 🚨

#163 의 후속 정정입니다. 해당 이슈에서 기본 권한 범위를 문서화하면서 들어간 표기를 실제 구현에 맞춥니다.

