### PR TITLE
docs: 선생님 회원가입 지원 반영해 userinfo·SDK 기술 문서 갱신

### DIFF
--- a/apps/docs/src/app/oauth/examples/nextjs-spring-boot/page.mdx
+++ b/apps/docs/src/app/oauth/examples/nextjs-spring-boot/page.mdx
@@ -975,8 +975,12 @@ public class DataGsmUserInfo {
     private Long id;
     private String email;
     private String role;
+    private String status;
+    private String objectType;
+    // isStudent는 Deprecated이며 objectType == "STUDENT"의 파생값입니다. 신규 연동은 objectType을 사용하세요.
     private Boolean isStudent;
     private StudentInfo student;
+    private TeacherInfo teacher;
 
     @Getter
     @Setter
@@ -989,6 +993,18 @@ public class DataGsmUserInfo {
         private Integer classNum;
         private Integer number;
         private String major;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TeacherInfo {
+        private Long id;
+        private String name;
+        private String email;
+        private String department;
+        private String description;
     }
 }
 

--- a/apps/docs/src/app/oauth/examples/react-spring-boot-kotlin/page.mdx
+++ b/apps/docs/src/app/oauth/examples/react-spring-boot-kotlin/page.mdx
@@ -243,12 +243,24 @@ interface StudentInfo {
   major: string;
 }
 
+interface TeacherInfo {
+  id: number;
+  name: string;
+  email: string;
+  department: string;
+  description?: string;
+}
+
 interface UserInfo {
   id: number;
   email: string;
   role: string;
+  status: string;
+  objectType?: string;
+  /** @deprecated objectType === 'STUDENT'의 파생값입니다. 신규 연동은 objectType을 사용하세요. */
   isStudent: boolean;
   student?: StudentInfo;
+  teacher?: TeacherInfo;
 }
 
 interface AuthResponse {
@@ -981,8 +993,12 @@ data class DataGsmUserInfo(
     val id: Long,
     val email: String,
     val role: String,
+    val status: String,
+    val objectType: String?,
+    // isStudent는 Deprecated이며 objectType == "STUDENT"의 파생값입니다. 신규 연동은 objectType을 사용하세요.
     val isStudent: Boolean,
-    val student: StudentInfo?
+    val student: StudentInfo?,
+    val teacher: TeacherInfo?
 ) {
     data class StudentInfo(
         val id: Long,
@@ -991,6 +1007,14 @@ data class DataGsmUserInfo(
         val classNum: Int,
         val number: Int,
         val major: String
+    )
+
+    data class TeacherInfo(
+        val id: Long,
+        val name: String,
+        val email: String,
+        val department: String,
+        val description: String?
     )
 }
 

--- a/apps/docs/src/app/oauth/examples/react-spring-boot/page.mdx
+++ b/apps/docs/src/app/oauth/examples/react-spring-boot/page.mdx
@@ -305,8 +305,12 @@ data class UserInfo(
     val id: Long,
     val email: String,
     val role: String,
+    val status: String,
+    val objectType: String?,
+    // isStudent는 Deprecated이며 objectType == "STUDENT"의 파생값입니다. 신규 연동은 objectType을 사용하세요.
     val isStudent: Boolean,
-    val student: StudentInfo?
+    val student: StudentInfo?,
+    val teacher: TeacherInfo?
 )
 
 data class StudentInfo(
@@ -316,6 +320,14 @@ data class StudentInfo(
     val classNum: Int,
     val number: Int,
     val major: String
+)
+
+data class TeacherInfo(
+    val id: Long,
+    val name: String,
+    val email: String,
+    val department: String,
+    val description: String?
 )`} />
 </CodeTabs>
 
@@ -588,12 +600,24 @@ interface StudentInfo {
   major: string;
 }
 
+interface TeacherInfo {
+  id: number;
+  name: string;
+  email: string;
+  department: string;
+  description?: string;
+}
+
 interface UserInfo {
   id: number;
   email: string;
   role: string;
+  status: string;
+  objectType?: string;
+  /** @deprecated objectType === 'STUDENT'의 파생값입니다. 신규 연동은 objectType을 사용하세요. */
   isStudent: boolean;
   student?: StudentInfo;
+  teacher?: TeacherInfo;
 }
 
 export function useAuth() {
@@ -969,6 +993,8 @@ describe('useAuth', () => {
         id: 1,
         email: 'test@gsm.hs.kr',
         role: 'USER',
+        status: 'ACTIVE',
+        objectType: 'STUDENT',
         isStudent: true,
         student: { id: 1, name: '홍길동', grade: 1, classNum: 1, number: 1, major: 'SW' },
       }),
@@ -988,7 +1014,7 @@ describe('useAuth', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
-          id: 1, email: 'test@gsm.hs.kr', role: 'USER', isStudent: true,
+          id: 1, email: 'test@gsm.hs.kr', role: 'USER', status: 'ACTIVE', objectType: 'STUDENT', isStudent: true,
           student: { id: 1, name: '홍길동', grade: 1, classNum: 1, number: 1, major: 'SW' },
         }),
       })

--- a/apps/docs/src/app/oauth/examples/vanilla-nestjs/page.mdx
+++ b/apps/docs/src/app/oauth/examples/vanilla-nestjs/page.mdx
@@ -946,12 +946,24 @@ interface StudentInfo {
   major: string;
 }
 
+interface TeacherInfo {
+  id: number;
+  name: string;
+  email: string;
+  department: string;
+  description?: string;
+}
+
 interface DataGsmUserInfo {
   id: number;
   email: string;
   role: string;
+  status: string;
+  objectType?: string;
+  /** @deprecated objectType === 'STUDENT'의 파생값입니다. 신규 연동은 objectType을 사용하세요. */
   isStudent: boolean;
   student?: StudentInfo;
+  teacher?: TeacherInfo;
 }
 
 @Injectable()
@@ -1084,12 +1096,24 @@ interface StudentInfo {
   major: string;
 }
 
+interface TeacherInfo {
+  id: number;
+  name: string;
+  email: string;
+  department: string;
+  description?: string;
+}
+
 interface DataGsmUserInfo {
   id: number;
   email: string;
   role: string;
+  status: string;
+  objectType?: string;
+  /** @deprecated objectType === 'STUDENT'의 파생값입니다. 신규 연동은 objectType을 사용하세요. */
   isStudent: boolean;
   student?: StudentInfo;
+  teacher?: TeacherInfo;
 }
 
 @Injectable()

--- a/apps/docs/src/app/oauth/http/userinfo/page.mdx
+++ b/apps/docs/src/app/oauth/http/userinfo/page.mdx
@@ -13,7 +13,7 @@ GET /userinfo
 ### 설명
 
 Access Token을 사용하여 인증된 사용자의 데이터를 조회합니다.
-이 엔드포인트는 사용자의 기본 데이터와 학생인 경우 학생 상세 데이터를 반환합니다.
+이 엔드포인트는 사용자의 기본 데이터와 연결된 대상(`objectType`)에 따라 학생 또는 선생님 상세 데이터를 반환합니다.
 
 ### 인증
 
@@ -36,6 +36,8 @@ Authorization: Bearer {accessToken}
   "id": 1,
   "email": "student@gsm.hs.kr",
   "role": "USER",
+  "status": "ACTIVE",
+  "objectType": "STUDENT",
   "isStudent": true,
   "student": {
     "id": 1,
@@ -51,7 +53,8 @@ Authorization: Bearer {accessToken}
     "dormitoryRoom": 301,
     "role": "GENERAL_STUDENT",
     "isLeaveSchool": false
-  }
+  },
+  "teacher": null
 }
 ```
 
@@ -59,17 +62,20 @@ Authorization: Bearer {accessToken}
 
 #### 사용자 기본 데이터
 
-| 필드          | 타입        | 설명                               | 예시                  |
-|-------------|-----------|----------------------------------|---------------------|
-| `id`        | `Long`    | 사용자 고유 ID                        | `1`                 |
-| `email`     | `String`  | 사용자 이메일 주소                       | `student@gsm.hs.kr` |
-| `role`      | `String`  | 사용자 역할 (`USER`, `ADMIN`)         | `USER`              |
-| `isStudent` | `Boolean` | 학생 여부                            | `true`              |
-| `student`   | `Object?` | 학생 상세 데이터 (학생인 경우만 제공, nullable) | -                   |
+| 필드          | 타입        | 설명                                                              | 예시                  |
+|-------------|-----------|-------------------------------------------------------------------|---------------------|
+| `id`        | `Long`    | 사용자 고유 ID                                                       | `1`                 |
+| `email`     | `String`  | 사용자 이메일 주소                                                     | `student@gsm.hs.kr` |
+| `role`      | `String`  | 사용자 역할 (`USER`, `ADMIN`)                                        | `USER`              |
+| `status`    | `String`  | 계정 상태 (`PENDING`, `ACTIVE`). 선생님 계정은 어드민 승인 전까지 `PENDING`으로 유지됩니다 | `ACTIVE`             |
+| `objectType`| `String?` | 연결된 대상 종류 (`STUDENT`, `TEACHER`, nullable)                      | `STUDENT`            |
+| `isStudent` | `Boolean` | **(Deprecated)** 학생 계정 여부. `objectType == STUDENT`의 파생값으로, 하위 호환을 위해 유지됩니다. 신규 연동은 `objectType`을 사용하세요 | `true`              |
+| `student`   | `Object?` | 학생 상세 데이터 (`objectType`이 `STUDENT`인 경우만 제공, nullable)          | -                   |
+| `teacher`   | `Object?` | 선생님 상세 데이터 (`objectType`이 `TEACHER`인 경우만 제공, nullable)         | -                   |
 
 #### 학생 상세 데이터 (student 객체)
 
-학생인 경우(`isStudent: true`) 다음 필드를 포함합니다.
+`objectType`이 `STUDENT`인 경우 다음 필드를 포함합니다.
 
 | 필드               | 타입        | 설명                                                                                         | 예시                |
 |------------------|-----------|--------------------------------------------------------------------------------------------|-------------------|
@@ -87,13 +93,25 @@ Authorization: Bearer {accessToken}
 | `role`           | `String`  | 학생 역할 (`STUDENT_COUNCIL`, `DORMITORY_MANAGER`, `GENERAL_STUDENT`, `GRADUATE`, `WITHDRAWN`) | `GENERAL_STUDENT` |
 | `isLeaveSchool`  | `Boolean` | 자퇴 여부                                                                                      | `false`           |
 
+#### 선생님 상세 데이터 (teacher 객체)
+
+`objectType`이 `TEACHER`인 경우 다음 필드를 포함합니다.
+
+| 필드            | 타입        | 설명                                                                    | 예시                 |
+|---------------|-----------|-----------------------------------------------------------------------|--------------------|
+| `id`          | `Long`    | 선생님 고유 ID                                                            | `1`                |
+| `name`        | `String`  | 선생님 이름                                                               | `김선생`             |
+| `email`       | `String`  | 선생님 이메일 주소                                                          | `teacher@gsm.hs.kr` |
+| `department`  | `String`  | 소속 부서 (`MEISTER`, `DORMITORY`, `GRADE`, `ACADEMIC_AFFAIRS`, `PROFESSIONAL_EDUCATION`, `EMPLOYMENT_CAREER`, `ADMINISTRATION`) | `GRADE`              |
+| `description` | `String?` | 선생님 설명 (미설정 시 `null`)                                               | `3학년 1반 담임선생님`  |
+
 ### 오류 응답
 
-| 상태 코드              | 설명           | 원인                         |
-|--------------------|--------------|----------------------------|
-| `401 Unauthorized` | 인증 실패        | Access Token이 유효하지 않거나 만료됨 |
-| `403 Forbidden`    | 권한 범위 부족     | 요청한 리소스에 대한 권한 범위 부족       |
-| `404 Not Found`    | 리소스를 찾을 수 없음 | 사용자 데이터를 찾을 수 없음           |
+| 상태 코드              | 설명           | 원인                                          |
+|--------------------|--------------|---------------------------------------------|
+| `401 Unauthorized` | 인증 실패        | Access Token이 유효하지 않거나 만료됨                    |
+| `403 Forbidden`    | 권한 범위 부족     | 요청한 리소스에 대한 권한 범위 부족, 또는 선생님 계정이 어드민 승인 대기(`PENDING`) 상태 |
+| `404 Not Found`    | 리소스를 찾을 수 없음 | 사용자 데이터를 찾을 수 없음                             |
 
 ### 요청 예시
 
@@ -113,6 +131,8 @@ curl -X GET "https://oauth.resource.datagsm.kr/userinfo" \
   "id": 1,
   "email": "student@gsm.hs.kr",
   "role": "USER",
+  "status": "ACTIVE",
+  "objectType": "STUDENT",
   "isStudent": true,
   "student": {
     "id": 1,
@@ -128,21 +148,33 @@ curl -X GET "https://oauth.resource.datagsm.kr/userinfo" \
     "dormitoryRoom": 301,
     "role": "GENERAL_STUDENT",
     "isLeaveSchool": false
-  }
+  },
+  "teacher": null
 }
 ```
 
-#### 비학생 사용자
+#### 선생님 사용자 (승인 완료)
 
 ```json
 {
   "id": 2,
   "email": "teacher@gsm.hs.kr",
-  "role": "ADMIN",
+  "role": "USER",
+  "status": "ACTIVE",
+  "objectType": "TEACHER",
   "isStudent": false,
-  "student": null
+  "student": null,
+  "teacher": {
+    "id": 1,
+    "name": "김선생",
+    "email": "teacher@gsm.hs.kr",
+    "department": "GRADE",
+    "description": "3학년 1반 담임선생님"
+  }
 }
 ```
+
+선생님 계정은 어드민 승인이 완료되어 `status`가 `ACTIVE`인 경우에만 로그인할 수 있습니다. `status`가 `PENDING`인 상태로 로그인을 시도하면 `403 Forbidden` 오류가 발생합니다.
 
 #### 실패 (401 Unauthorized)
 
@@ -187,10 +219,14 @@ const userInfo = await getUserInfo(accessToken);
 console.log('User ID:', userInfo.id);
 console.log('Email:', userInfo.email);
 
-if (userInfo.isStudent) {
+// isStudent는 Deprecated이며 objectType == 'STUDENT'의 파생값입니다. 신규 연동은 objectType을 사용하세요.
+if (userInfo.objectType === 'STUDENT') {
   console.log('Student Name:', userInfo.student.name);
   console.log('Grade:', userInfo.student.grade);
   console.log('Class:', userInfo.student.classNum);
+} else if (userInfo.objectType === 'TEACHER') {
+  console.log('Teacher Name:', userInfo.teacher.name);
+  console.log('Department:', userInfo.teacher.department);
 }`} />
 
   <CodeTab label="Python" language="python" code={`import requests
@@ -223,11 +259,16 @@ user_info = get_user_info(access_token)
 print(f'User ID: {user_info["id"]}')
 print(f'Email: {user_info["email"]}')
 
-if user_info['isStudent']:
+# isStudent는 Deprecated이며 objectType == 'STUDENT'의 파생값입니다. 신규 연동은 objectType을 사용하세요.
+if user_info['objectType'] == 'STUDENT':
     student = user_info['student']
     print(f'Student Name: {student["name"]}')
     print(f'Grade: {student["grade"]}')
-    print(f'Class: {student["classNum"]}')`} />
+    print(f'Class: {student["classNum"]}')
+elif user_info['objectType'] == 'TEACHER':
+    teacher = user_info['teacher']
+    print(f'Teacher Name: {teacher["name"]}')
+    print(f'Department: {teacher["department"]}')`} />
 
   <CodeTab label="Java" language="java" code={`import java.net.http.*;
 import java.net.URI;
@@ -264,8 +305,12 @@ public class UserInfoService {
         public Long id;
         public String email;
         public String role;
+        public String status;
+        public String objectType;
+        // isStudent는 Deprecated이며 objectType == "STUDENT"의 파생값입니다. 신규 연동은 objectType을 사용하세요.
         public Boolean isStudent;
         public Student student;
+        public Teacher teacher;
     }
 
     public static class Student {
@@ -284,6 +329,14 @@ public class UserInfoService {
         public Boolean isLeaveSchool;
     }
 
+    public static class Teacher {
+        public Long id;
+        public String name;
+        public String email;
+        public String department;
+        public String description;
+    }
+
     public static void main(String[] args) throws Exception {
         String accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...";
         UserInfo userInfo = getUserInfo(accessToken);
@@ -291,9 +344,12 @@ public class UserInfoService {
         System.out.println("User ID: " + userInfo.id);
         System.out.println("Email: " + userInfo.email);
 
-        if (userInfo.isStudent && userInfo.student != null) {
+        if ("STUDENT".equals(userInfo.objectType) && userInfo.student != null) {
             System.out.println("Student Name: " + userInfo.student.name);
             System.out.println("Grade: " + userInfo.student.grade);
+        } else if ("TEACHER".equals(userInfo.objectType) && userInfo.teacher != null) {
+            System.out.println("Teacher Name: " + userInfo.teacher.name);
+            System.out.println("Department: " + userInfo.teacher.department);
         }
     }
 }`} />
@@ -309,8 +365,12 @@ data class UserInfo(
     val id: Long,
     val email: String,
     val role: String,
+    val status: String,
+    val objectType: String?,
+    @Deprecated("objectType == \\"STUDENT\\" 으로 대체 예정, 하위 호환을 위해 임시 유지")
     val isStudent: Boolean,
-    val student: Student?
+    val student: Student?,
+    val teacher: Teacher?
 )
 
 data class Student(
@@ -327,6 +387,14 @@ data class Student(
     val dormitoryRoom: Int?,
     val role: String,
     val isLeaveSchool: Boolean
+)
+
+data class Teacher(
+    val id: Long,
+    val name: String,
+    val email: String,
+    val department: String,
+    val description: String?
 )
 
 class UserInfoService {
@@ -359,10 +427,14 @@ fun main() {
     println("User ID: \${userInfo.id}")
     println("Email: \${userInfo.email}")
 
-    if (userInfo.isStudent && userInfo.student != null) {
+    // isStudent는 Deprecated이며 objectType == "STUDENT"의 파생값입니다. 신규 연동은 objectType을 사용하세요.
+    if (userInfo.objectType == "STUDENT" && userInfo.student != null) {
         println("Student Name: \${userInfo.student.name}")
         println("Grade: \${userInfo.student.grade}")
         println("Class: \${userInfo.student.classNum}")
+    } else if (userInfo.objectType == "TEACHER" && userInfo.teacher != null) {
+        println("Teacher Name: \${userInfo.teacher.name}")
+        println("Department: \${userInfo.teacher.department}")
     }
 }`} />
 </CodeTabs>
@@ -388,6 +460,38 @@ fun main() {
 | `DORMITORY_MANAGER` | 기숙사 사감 |
 | `GRADUATE` | 졸업생 |
 | `WITHDRAWN` | 자퇴생 |
+
+### 선생님 부서 코드 (Department)
+
+`teacher.department` 필드는 다음 값 중 하나입니다.
+
+| 코드 | 설명 |
+| --- | --- |
+| `MEISTER` | 마이스터부 |
+| `DORMITORY` | 사감선생님 |
+| `GRADE` | 학년부 |
+| `ACADEMIC_AFFAIRS` | 교무부 |
+| `PROFESSIONAL_EDUCATION` | 전문교육부 |
+| `EMPLOYMENT_CAREER` | 취업진로부 |
+| `ADMINISTRATION` | 행정실 |
+
+### 계정 상태 코드 (Status)
+
+`status` 필드는 다음 값 중 하나입니다.
+
+| 코드 | 설명 |
+| --- | --- |
+| `PENDING` | 어드민 승인 대기 중 (선생님 회원가입 직후). 이 상태에서는 로그인이 차단되어 Access Token을 발급받을 수 없습니다 |
+| `ACTIVE` | 활성화된 계정. 학생은 이메일 인증 후 즉시 `ACTIVE`가 되며, 선생님은 어드민 승인 후 `ACTIVE`가 됩니다 |
+
+### 연결 대상 종류 (Object Type)
+
+`objectType` 필드는 다음 값 중 하나입니다.
+
+| 코드 | 설명 |
+| --- | --- |
+| `STUDENT` | 학생 계정. `student` 필드에 상세 데이터가 포함됩니다 |
+| `TEACHER` | 선생님 계정. `teacher` 필드에 상세 데이터가 포함됩니다 |
 
 ### 보안 주의사항
 

--- a/apps/docs/src/app/oauth/sdk/java/page.mdx
+++ b/apps/docs/src/app/oauth/sdk/java/page.mdx
@@ -10,6 +10,8 @@ export const metadata = createDocsPageMetadata({ title: "Java / Kotlin SDK", pat
 
 이 SDK를 사용하면 복잡한 OAuth 인증 플로우를 직접 구현할 필요 없이, 간단한 인터페이스를 통해 Authorization Code 교환, PKCE 지원, 토큰 갱신, 사용자 데이터 조회 등의 기능을 손쉽게 사용할 수 있습니다.
 
+> **참고**: `status`, `objectType`, `teacher` 필드는 서버의 선생님 회원가입 지원([datagsm-server#401](https://github.com/themoment-team/datagsm-server/pull/401))에 맞춰 SDK에 추가될 예정입니다. 진행 상황은 [datagsm-oauth-sdk-java#12](https://github.com/themoment-team/datagsm-oauth-sdk-java/issues/12)에서 확인하세요.
+
 ### 주요 특징
 
 | 특징                  | 설명                                                                  |
@@ -192,6 +194,8 @@ val limitedTokenResponse = client.refreshToken(refreshToken, "read")`} />
 <CodeTabs>
   <CodeTab label="Java" language="java" code={`import team.themoment.datagsm.sdk.oauth.model.UserInfo;
 import team.themoment.datagsm.sdk.oauth.model.Student;
+import team.themoment.datagsm.sdk.oauth.model.Teacher;
+import team.themoment.datagsm.sdk.oauth.model.AccountObjectType;
 
 // Access Token으로 사용자 데이터 조회
 UserInfo userInfo = client.getUserInfo(accessToken);
@@ -200,19 +204,28 @@ UserInfo userInfo = client.getUserInfo(accessToken);
 System.out.println("ID: " + userInfo.getId());
 System.out.println("이메일: " + userInfo.getEmail());
 System.out.println("역할: " + userInfo.getRole());
+System.out.println("상태: " + userInfo.getStatus());       // PENDING, ACTIVE
 
-// 학생인 경우 추가 데이터 조회
-if (userInfo.isStudent()) {
+// objectType 기준으로 학생/선생님 데이터 분기 조회
+// isStudent()/getIsStudent()는 Deprecated이며 objectType == STUDENT 파생값입니다.
+if (userInfo.getObjectType() == AccountObjectType.STUDENT) {
     Student student = userInfo.getStudent();
     System.out.println("이름: " + student.getName());
     System.out.println("학번: " + student.getStudentNumber());
     System.out.println("학년: " + student.getGrade());
     System.out.println("반: " + student.getClassNum());
     System.out.println("학과: " + student.getMajor());
+} else if (userInfo.getObjectType() == AccountObjectType.TEACHER) {
+    Teacher teacher = userInfo.getTeacher();
+    System.out.println("이름: " + teacher.getName());
+    System.out.println("부서: " + teacher.getDepartment());
+    System.out.println("설명: " + teacher.getDescription());
 }`} />
 
   <CodeTab label="Kotlin" language="kotlin" code={`import team.themoment.datagsm.sdk.oauth.model.UserInfo
 import team.themoment.datagsm.sdk.oauth.model.Student
+import team.themoment.datagsm.sdk.oauth.model.Teacher
+import team.themoment.datagsm.sdk.oauth.model.AccountObjectType
 
 // Access Token으로 사용자 데이터 조회
 val userInfo = client.getUserInfo(accessToken)
@@ -221,15 +234,26 @@ val userInfo = client.getUserInfo(accessToken)
 println("ID: \${userInfo.id}")
 println("이메일: \${userInfo.email}")
 println("역할: \${userInfo.role}")
+println("상태: \${userInfo.status}")   // PENDING, ACTIVE
 
-// 학생인 경우 추가 데이터 조회
-if (userInfo.isStudent) {
-    val student = userInfo.student
-    println("이름: \${student.name}")
-    println("학번: \${student.studentNumber}")
-    println("학년: \${student.grade}")
-    println("반: \${student.classNum}")
-    println("학과: \${student.major}")
+// objectType 기준으로 학생/선생님 데이터 분기 조회
+// isStudent는 Deprecated이며 objectType == STUDENT 파생값입니다.
+when (userInfo.objectType) {
+    AccountObjectType.STUDENT -> {
+        val student = userInfo.student
+        println("이름: \${student.name}")
+        println("학번: \${student.studentNumber}")
+        println("학년: \${student.grade}")
+        println("반: \${student.classNum}")
+        println("학과: \${student.major}")
+    }
+    AccountObjectType.TEACHER -> {
+        val teacher = userInfo.teacher
+        println("이름: \${teacher.name}")
+        println("부서: \${teacher.department}")
+        println("설명: \${teacher.description}")
+    }
+    else -> {}
 }`} />
 
 </CodeTabs>
@@ -409,9 +433,9 @@ SDK는 다음과 같은 API 메서드를 제공합니다.
 |---------------|----------|--------------|
 | `accessToken` | `String` | Access Token |
 
-| 반환 타입      | 설명                         |
-|------------|----------------------------|
-| `UserInfo` | 사용자 데이터 (학생인 경우 학생 데이터 포함) |
+| 반환 타입      | 설명                                           |
+|------------|----------------------------------------------|
+| `UserInfo` | 사용자 데이터 (`objectType`에 따라 학생 또는 선생님 데이터 포함) |
 
 ## 모델 레퍼런스
 
@@ -445,13 +469,16 @@ Authorization URL 빌더 모델
 
 사용자 데이터 모델
 
-| 필드          | 타입            | 설명              |
-|-------------|---------------|-----------------|
-| `id`        | `Long`        | 사용자 고유 ID       |
-| `email`     | `String`      | 이메일 주소          |
-| `role`      | `AccountRole` | 계정 역할           |
-| `isStudent` | `Boolean`     | 학생 여부           |
-| `student`   | `Student`     | 학생 데이터 (학생인 경우) |
+| 필드           | 타입                | 설명                                                                        |
+|--------------|-------------------|---------------------------------------------------------------------------|
+| `id`         | `Long`            | 사용자 고유 ID                                                                 |
+| `email`      | `String`          | 이메일 주소                                                                    |
+| `role`       | `AccountRole`     | 계정 역할                                                                     |
+| `status`     | `AccountStatus`   | 계정 상태 (`PENDING`, `ACTIVE`). 선생님 계정은 어드민 승인 전까지 `PENDING`으로 유지됩니다              |
+| `objectType` | `AccountObjectType?` | 연결된 대상 종류 (`STUDENT`, `TEACHER`, nullable)                             |
+| `isStudent`  | `Boolean`         | **(Deprecated)** 학생 계정 여부. `objectType == STUDENT`의 파생값이며, 신규 연동은 `objectType`을 사용하세요 |
+| `student`    | `Student?`        | 학생 데이터 (`objectType`이 `STUDENT`인 경우, nullable)                          |
+| `teacher`    | `Teacher?`        | 선생님 데이터 (`objectType`이 `TEACHER`인 경우, nullable)                         |
 
 ### Student
 
@@ -477,6 +504,18 @@ Authorization URL 빌더 모델
 | `githubId`       | `String`      | GitHub 아이디  |
 | `githubUrl`      | `String`      | GitHub 프로필 URL |
 
+### Teacher
+
+선생님 데이터 모델
+
+| 필드            | 타입                | 설명                     |
+|---------------|-------------------|------------------------|
+| `id`          | `Long`            | 선생님 고유 ID              |
+| `name`        | `String`          | 이름                     |
+| `email`       | `String`          | 이메일                    |
+| `department`  | `TeacherDepartment` | 소속 부서                |
+| `description` | `String?`         | 선생님 설명 (미설정 시 `null`) |
+
 ### ClubInfo
 
 동아리 데이터 모델
@@ -500,6 +539,32 @@ Authorization URL 빌더 모델
 | `ADMIN`        | 관리자       |
 | `USER`         | 일반 사용자    |
 | `API_KEY_USER` | API 키 사용자 |
+
+#### AccountStatus
+
+| 값         | 설명                                             |
+|-----------|------------------------------------------------|
+| `PENDING` | 어드민 승인 대기 중 (선생님 회원가입 직후). 로그인이 차단되어 Access Token을 발급받을 수 없습니다 |
+| `ACTIVE`  | 활성화된 계정 (학생은 이메일 인증 후, 선생님은 어드민 승인 후 전환됩니다)     |
+
+#### AccountObjectType
+
+| 값         | 설명                                    |
+|-----------|---------------------------------------|
+| `STUDENT` | 학생 계정. `UserInfo.student`에 상세 데이터 포함  |
+| `TEACHER` | 선생님 계정. `UserInfo.teacher`에 상세 데이터 포함 |
+
+#### TeacherDepartment
+
+| 값                         | 설명       |
+|---------------------------|----------|
+| `MEISTER`                 | 마이스터부    |
+| `DORMITORY`                | 사감선생님   |
+| `GRADE`                    | 학년부      |
+| `ACADEMIC_AFFAIRS`          | 교무부      |
+| `PROFESSIONAL_EDUCATION`   | 전문교육부   |
+| `EMPLOYMENT_CAREER`        | 취업진로부   |
+| `ADMINISTRATION`            | 행정실      |
 
 #### Sex
 
@@ -845,9 +910,10 @@ public class Main {
             System.out.printf("사용자 ID: %d%n", userInfo.getId());
             System.out.printf("이메일: %s%n", userInfo.getEmail());
             System.out.printf("역할: %s%n", userInfo.getRole());
+            System.out.printf("상태: %s%n", userInfo.getStatus());
 
-            // 4. 학생 데이터 조회 (학생인 경우)
-            if (userInfo.isStudent()) {
+            // 4. objectType 기준으로 학생/선생님 데이터 분기 조회
+            if (userInfo.getObjectType() == AccountObjectType.STUDENT) {
                 Student student = userInfo.getStudent();
                 System.out.printf("이름: %s%n", student.getName());
                 System.out.printf("학번: %d%n", student.getStudentNumber());
@@ -859,6 +925,10 @@ public class Main {
                 if (student.getMajorClub() != null) {
                     System.out.printf("전공동아리: %s%n", student.getMajorClub().getName());
                 }
+            } else if (userInfo.getObjectType() == AccountObjectType.TEACHER) {
+                Teacher teacher = userInfo.getTeacher();
+                System.out.printf("이름: %s%n", teacher.getName());
+                System.out.printf("부서: %s%n", teacher.getDepartment());
             }
 
             // 5. 토큰 갱신
@@ -913,19 +983,28 @@ fun main() {
             println("사용자 ID: \${userInfo.id}")
             println("이메일: \${userInfo.email}")
             println("역할: \${userInfo.role}")
+            println("상태: \${userInfo.status}")
 
-            // 4. 학생 데이터 조회 (학생인 경우)
-            if (userInfo.isStudent) {
-                val student = userInfo.student
-                println("이름: \${student.name}")
-                println("학번: \${student.studentNumber}")
-                println("학년/반/번호: \${student.grade}학년 \${student.classNum}반 \${student.number}번")
-                println("학과: \${student.major}")
+            // 4. objectType 기준으로 학생/선생님 데이터 분기 조회
+            when (userInfo.objectType) {
+                AccountObjectType.STUDENT -> {
+                    val student = userInfo.student
+                    println("이름: \${student.name}")
+                    println("학번: \${student.studentNumber}")
+                    println("학년/반/번호: \${student.grade}학년 \${student.classNum}반 \${student.number}번")
+                    println("학과: \${student.major}")
 
-                // 동아리 데이터
-                student.majorClub?.let { club ->
-                    println("전공동아리: \${club.name}")
+                    // 동아리 데이터
+                    student.majorClub?.let { club ->
+                        println("전공동아리: \${club.name}")
+                    }
                 }
+                AccountObjectType.TEACHER -> {
+                    val teacher = userInfo.teacher
+                    println("이름: \${teacher.name}")
+                    println("부서: \${teacher.department}")
+                }
+                else -> {}
             }
 
             // 5. 토큰 갱신

--- a/apps/docs/src/app/oauth/sdk/page.mdx
+++ b/apps/docs/src/app/oauth/sdk/page.mdx
@@ -31,7 +31,7 @@ SDK는 응답 데이터 구조를 명확한 클래스로 정의하여 제공합�
 // ✅ SDK 사용 - 타입 안전하며 자동완성 지원
 UserInfo userInfo = client.getUserInfo(accessToken);
 String email = userInfo.getEmail();
-if (userInfo.isStudent()) {
+if (userInfo.getObjectType() == AccountObjectType.STUDENT) {
     String major = userInfo.getStudent().getMajor(); // 컴파일 타임에 타입 체크
 }
 
@@ -101,7 +101,7 @@ SDK는 DataGSM OAuth의 핵심 기능을 모두 포함하고 있습니다:
 |----------------|--------------------------------------------|--------------|
 | **인증 코드 교환**   | Authorization Code를 Access/Refresh 토큰으로 교환 | Java, Kotlin |
 | **토큰 갱신**      | Refresh Token을 사용하여 Access Token 재발급       | Java, Kotlin |
-| **사용자 데이터 조회** | 인증된 사용자의 기본 프로필 및 학생 데이터 조회                | Java, Kotlin |
+| **사용자 데이터 조회** | 인증된 사용자의 기본 프로필 및 학생/선생님 상세 데이터 조회        | Java, Kotlin |
 | **로그인 UI 제공**  | 표준화된 디자인의 "DataGSM 로그인" 버튼 제공              | React        |
 | **인증 상태 관리**   | 애플리케이션 전역의 인증 컨텍스트 관리                      | React        |
 


### PR DESCRIPTION
## 개요 💡

서버(datagsm-server)의 선생님 회원가입 및 어드민 승인 기능 추가로 `/userinfo` 응답 구조가 변경되었으나, 기술 문서가 이를 반영하지 못해 서버와 불일치가 발생했습니다. 관련 서버 PR과 SDK 실제 코드를 확인해 문서를 최신 상태로 동기화했습니다.

- https://github.com/themoment-team/datagsm-server/pull/401
- https://github.com/themoment-team/datagsm-server/pull/404

## 작업내용 ⌨️

- `oauth/http/userinfo`: `status`(`PENDING`/`ACTIVE`), `objectType`(`STUDENT`/`TEACHER`), `teacher` 필드 문서화. `isStudent`는 Deprecated로 표기(서버가 하위 호환을 위해 `objectType == STUDENT` 파생값으로 유지). 선생님 상세 데이터, 부서 코드(`TeacherDepartment`), 계정 상태 코드, 어드민 승인 대기 시 `403 Forbidden` 안내 추가. JS/Python/Java/Kotlin 예제를 `objectType` 분기 기준으로 갱신
- `oauth/sdk`, `oauth/sdk/java`: SDK 실제 코드(`UserInfo.java`)를 확인한 결과 SDK가 아직 신규 필드를 지원하지 않는 구버전임을 확인. SDK가 필드를 지원할 예정이라는 전제로 `UserInfo`/`Teacher` 모델, 관련 Enum, 코드 예제를 갱신하고 SDK 추적 이슈 링크 안내 추가
- `oauth/examples/*` (react-spring-boot, react-spring-boot-kotlin, nextjs-spring-boot, vanilla-nestjs): REST API 직접 연동 예제의 DTO/interface에도 동일하게 `status`, `objectType`, `teacher` 반영

### 별도 처리

- Java/Kotlin SDK(`datagsm-oauth-sdk-java`)가 아직 신규 필드를 지원하지 않아 필드 추가 요청 이슈를 생성했습니다: https://github.com/themoment-team/datagsm-oauth-sdk-java/issues/12
- React SDK(`datagsm-oauth-sdk-react`)는 사용자 데이터 모델 자체를 다루지 않아(로그인 UI/인증 상태 관리만 제공) 이슈 생성 대상이 아님을 확인했습니다.

## 관련 이슈 🚨

closes #201

## 리뷰 요청사항 👀

- SDK가 아직 신규 필드를 지원하지 않는 상태에서 문서를 먼저 갱신하는 방향이 맞는지 확인 부탁드립니다. (SDK 이슈 #12 진행 상황에 따라 문서 재조정 필요할 수 있음)