### PR TITLE
[oauth] OAuth 로그인·회원가입 화면 신규 디자인 반영

### DIFF
--- a/apps/oauth/src/app/signup/teacher/page.tsx
+++ b/apps/oauth/src/app/signup/teacher/page.tsx
@@ -1,0 +1,7 @@
+import { SignUpPage } from '@/views/signup';
+
+const TeacherSignUp = () => {
+  return <SignUpPage objectType="TEACHER" />;
+};
+
+export default TeacherSignUp;

--- a/apps/oauth/src/entities/signup/model/schema.ts
+++ b/apps/oauth/src/entities/signup/model/schema.ts
@@ -1,40 +1,44 @@
 import { TEACHER_DEPARTMENT_OPTIONS, TeacherDepartment } from '@repo/shared/types';
-
 import { z } from 'zod';
 
-export const SignUpFormSchema = z
-  .object({
-    objectType: z.enum(['STUDENT', 'TEACHER'], {
-      message: '가입 종류를 선택해주세요.',
-    }),
-    email: z.string().min(1, { message: '이메일을 입력해주세요.' }),
-    password: z
-      .string()
-      .min(1, { message: '비밀번호를 입력해주세요.' })
-      .min(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
-      .max(100, { message: '비밀번호는 최대 100자 이하여야 합니다.' })
-      .regex(/^(?=.*[a-zA-Z])(?=.*[0-9])/, {
-        message: '비밀번호는 영문과 숫자를 포함해야 합니다.',
-      }),
-    confirmPassword: z.string().min(1, { message: '비밀번호 확인을 입력해주세요.' }),
-    code: z
-      .string()
-      .min(1, { message: '인증 코드를 입력해주세요.' })
-      .length(8, { message: '인증 코드는 8자리입니다.' }),
-    privacyAgreed: z.boolean().refine((val) => val === true, {
-      message: '개인정보 처리방침에 동의해주세요.',
-    }),
-    name: z.string().max(10, { message: '성함은 최대 10자 이하여야 합니다.' }).optional(),
-    department: z.enum(TEACHER_DEPARTMENT_OPTIONS).optional(),
-    description: z.string().max(100, { message: '설명은 최대 100자 이하여야 합니다.' }).optional(),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    message: '비밀번호가 일치하지 않습니다.',
-    path: ['confirmPassword'],
-  })
-  .superRefine((data, ctx) => {
-    if (data.objectType !== 'TEACHER') return;
+export type SignUpObjectType = 'STUDENT' | 'TEACHER';
 
+const signUpFields = {
+  email: z.string().min(1, { message: '이메일을 입력해주세요.' }),
+  password: z
+    .string()
+    .min(1, { message: '비밀번호를 입력해주세요.' })
+    .min(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
+    .max(100, { message: '비밀번호는 최대 100자 이하여야 합니다.' })
+    .regex(/^(?=.*[a-zA-Z])(?=.*[0-9])/, {
+      message: '비밀번호는 영문과 숫자를 포함해야 합니다.',
+    }),
+  confirmPassword: z.string().min(1, { message: '비밀번호 확인을 입력해주세요.' }),
+  code: z
+    .string()
+    .min(1, { message: '인증 코드를 입력해주세요.' })
+    .length(8, { message: '인증 코드는 8자리입니다.' }),
+  privacyAgreed: z.boolean().refine((val) => val === true, {
+    message: '개인정보 처리방침에 동의해주세요.',
+  }),
+  name: z.string().max(10, { message: '성함은 최대 10자 이하여야 합니다.' }).optional(),
+  department: z.enum(TEACHER_DEPARTMENT_OPTIONS).optional(),
+  description: z.string().max(100, { message: '설명은 최대 100자 이하여야 합니다.' }).optional(),
+};
+
+const passwordMatchOptions = {
+  message: '비밀번호가 일치하지 않습니다.',
+  path: ['confirmPassword'],
+};
+
+export const StudentSignUpFormSchema = z
+  .object(signUpFields)
+  .refine((data) => data.password === data.confirmPassword, passwordMatchOptions);
+
+export const TeacherSignUpFormSchema = z
+  .object(signUpFields)
+  .refine((data) => data.password === data.confirmPassword, passwordMatchOptions)
+  .superRefine((data, ctx) => {
     if (!data.name?.trim()) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -52,7 +56,10 @@ export const SignUpFormSchema = z
     }
   });
 
-export type SignUpFormType = z.infer<typeof SignUpFormSchema>;
+export const getSignUpFormSchema = (objectType: SignUpObjectType) =>
+  objectType === 'TEACHER' ? TeacherSignUpFormSchema : StudentSignUpFormSchema;
+
+export type SignUpFormType = z.infer<typeof StudentSignUpFormSchema>;
 
 interface StudentSignUpRequest {
   objectType: 'STUDENT';

--- a/apps/oauth/src/views/signup/ui/SignUpPage/index.tsx
+++ b/apps/oauth/src/views/signup/ui/SignUpPage/index.tsx
@@ -1,11 +1,16 @@
 import { cn } from '@repo/shared/utils';
 
+import { SignUpObjectType } from '@/entities/signup';
 import { SignUpForm } from '@/widgets/signup';
 
-const SignUpPage = () => {
+interface SignUpPageProps {
+  objectType?: SignUpObjectType;
+}
+
+const SignUpPage = ({ objectType = 'STUDENT' }: SignUpPageProps) => {
   return (
-    <div className={cn('bg-background flex min-h-screen items-center justify-center px-4')}>
-      <SignUpForm />
+    <div className={cn('bg-background flex min-h-screen items-center justify-center px-4 py-10')}>
+      <SignUpForm objectType={objectType} />
     </div>
   );
 };

--- a/apps/oauth/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
+++ b/apps/oauth/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
@@ -15,12 +15,6 @@ import { useGetOAuthSession } from '@/widgets/oauth';
 const BUFFER_TIME_MS = 30000;
 const STORAGE_KEY = 'oauth_session_timestamp';
 
-const WARNING_CONFIG = [
-  { time: 300, key: 'fiveMin', message: '5분 후 세션이 만료됩니다.' },
-  { time: 60, key: 'oneMin', message: '1분 후 세션이 만료됩니다.' },
-  { time: 30, key: 'thirtySec', message: '30초 후 세션이 만료됩니다.' },
-] as const;
-
 const OAuthAuthorizeForm = () => {
   const [isPending, setIsPending] = useState(false);
   const [remainingTime, setRemainingTime] = useState<number | null>(null);
@@ -29,12 +23,7 @@ const OAuthAuthorizeForm = () => {
   const token = searchParams.get('token');
 
   const sessionExpiresAt = useRef<number | null>(null);
-  const hasShownWarnings = useRef<Record<string, boolean>>({
-    fiveMin: false,
-    oneMin: false,
-    thirtySec: false,
-    expired: false,
-  });
+  const hasShownExpiredToast = useRef(false);
   const { data: sessionResponse, isLoading: isLoadingServiceInfo } = useGetOAuthSession(token);
   const sessionData = sessionResponse?.data;
   const serviceName = sessionData?.serviceName;
@@ -51,19 +40,11 @@ const OAuthAuthorizeForm = () => {
 
     if (remaining <= 0) {
       setIsExpired(true);
-      if (!hasShownWarnings.current.expired) {
-        hasShownWarnings.current.expired = true;
+      if (!hasShownExpiredToast.current) {
+        hasShownExpiredToast.current = true;
         toast.error('인증 세션이 만료되었습니다. 처음부터 다시 시도해주세요.');
       }
       return true;
-    }
-
-    for (const { time, key, message } of WARNING_CONFIG) {
-      if (remaining <= time && !hasShownWarnings.current[key]) {
-        hasShownWarnings.current[key] = true;
-        toast.info(message);
-        break;
-      }
     }
 
     return false;

--- a/apps/oauth/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
+++ b/apps/oauth/src/widgets/oauth/ui/OAuthAuthorizeForm/index.tsx
@@ -7,7 +7,6 @@ import { useSearchParams } from 'next/navigation';
 import { SignInFormType } from '@repo/shared/types';
 import { SignInForm } from '@repo/shared/ui';
 import { cn } from '@repo/shared/utils';
-import { AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { useGetOAuthSession } from '@/widgets/oauth';
@@ -185,18 +184,44 @@ const OAuthAuthorizeForm = () => {
       {isExpired && (
         <div
           className={cn(
-            'bg-background/80 fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm',
+            'bg-background fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm',
           )}
         >
-          <div className="border-destructive bg-background pixel-shadow flex max-w-md flex-col items-center gap-4 border-2 p-8 text-center">
-            <div className="border-destructive border-2 p-3">
-              <AlertCircle className="text-destructive h-8 w-8" />
+          <div
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="session-expired-title"
+            aria-describedby="session-expired-description"
+            className={cn('border-destructive bg-background max-w-100 w-full border-2')}
+          >
+            <div className={cn('bg-destructive flex items-center gap-3 px-4 py-3')}>
+              <div
+                className={cn(
+                  'bg-background text-destructive font-pixel flex size-6 flex-shrink-0 items-center justify-center text-[8px]',
+                )}
+              >
+                D
+              </div>
+              <span className={cn('text-background font-pixel text-[9px]')}>DataGSM</span>
+              <span className={cn('text-background font-pixel text-[9px]')}>Session</span>
+              <span className={cn('text-background font-pixel text-[9px]')}>Expiration</span>
             </div>
-            <h2 className="text-foreground text-xl font-bold">인증 세션 만료</h2>
-            <p className="text-muted-foreground text-sm">
-              보안을 위해 인증 세션이 만료되었습니다.
-              <br />이 창을 닫고 서비스에서 다시 로그인을 시도해주세요.
-            </p>
+
+            <div className={cn('flex flex-col items-center gap-2 p-5 text-center')}>
+              <h2
+                id="session-expired-title"
+                className={cn('text-destructive text-xl font-semibold leading-[1.45]')}
+              >
+                인증 세션 만료
+              </h2>
+              <p
+                id="session-expired-description"
+                className={cn('text-muted-foreground text-xs leading-[18px]')}
+              >
+                보안을 위해 인증 세션이 만료되었습니다.
+                <br />이 창을 닫고 서비스에서 다시 로그인을 시도하세요.
+              </p>
+            </div>
           </div>
         </div>
       )}

--- a/apps/oauth/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
+++ b/apps/oauth/src/widgets/reset-password/ui/ResetPasswordForm/index.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/navigation';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { EMAIL_DOMAIN } from '@repo/shared/constants';
 import { useDebounce } from '@repo/shared/hooks';
-import { FormErrorMessage, Input, Label } from '@repo/shared/ui';
+import { FormErrorMessage, Input } from '@repo/shared/ui';
 import { cn, formatEmailWithDomain, getApiErrorCode, minutesToMs } from '@repo/shared/utils';
 import { Eye, EyeOff } from 'lucide-react';
 import { SubmitHandler, useForm } from 'react-hook-form';
@@ -19,6 +19,10 @@ import {
   useSendPasswordResetEmail,
   useVerifyPasswordResetCode,
 } from '@/widgets/reset-password';
+
+const ERROR_MESSAGE_CLASS = "text-destructive text-xs leading-4 before:mr-1 before:content-['>']";
+const FIELD_CLASS =
+  'border-foreground focus-visible:border-foreground aria-invalid:border-destructive aria-invalid:text-destructive rounded-none focus-visible:ring-0';
 
 const RESEND_COOLDOWN_MS = minutesToMs(5);
 const STORAGE_KEY = 'password_reset_verification_timestamp';
@@ -208,68 +212,71 @@ const ResetPasswordForm = () => {
   };
 
   return (
-    <div className={cn('border-foreground bg-background pixel-shadow-lg w-full max-w-md border-2')}>
+    <div className={cn('border-foreground bg-background max-w-100 w-full border-2')}>
       {/* Title bar */}
       <div
         className={cn(
-          'border-foreground bg-foreground flex items-center gap-3 border-b-2 px-5 py-3',
+          'border-foreground bg-foreground flex items-center gap-3 border-b-2 px-4 py-3',
         )}
       >
         <div
           className={cn(
-            'bg-background text-foreground font-pixel flex h-6 w-6 flex-shrink-0 items-center justify-center text-[8px]',
+            'bg-background text-foreground font-pixel flex size-6 flex-shrink-0 items-center justify-center text-[8px]',
           )}
         >
           D
         </div>
         <span className={cn('text-background font-pixel text-[9px]')}>DataGSM</span>
+        <span className={cn('text-background font-pixel text-[9px]')}>Reset Password</span>
       </div>
 
       {/* Header */}
-      <div className={cn('border-border/50 border-b px-6 py-5')}>
-        <h1 className={cn('text-foreground text-xl font-bold')}>비밀번호 재설정</h1>
-        <p className={cn('text-muted-foreground mt-1 text-sm')}>새로운 비밀번호를 설정하세요</p>
+      <div className={cn('border-border/50 flex flex-col gap-2 border-b p-5')}>
+        <h1 className={cn('text-foreground text-xl font-semibold leading-[1.45]')}>
+          비밀번호 초기화
+        </h1>
+        <p className={cn('text-muted-foreground text-xs leading-[18px]')}>
+          <span className={cn('font-mono font-bold')}>{EMAIL_DOMAIN}</span> 도메인 계정만 사용
+          가능합니다.
+        </p>
       </div>
 
       <form onSubmit={handleSubmit(onSubmit)}>
-        <div className={cn('space-y-4 px-6 pt-5')}>
-          {/* Email + code send */}
-          <div className={cn('space-y-1.5')}>
-            <Label
-              htmlFor="email"
-              className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
-            >
-              Email
-            </Label>
-            <div className={cn('flex gap-2')}>
-              <div className={cn('flex-1 space-y-1')}>
-                <div className={cn('flex items-center')}>
+        <div className={cn('flex flex-col gap-5 px-5 pt-5')}>
+          {/* 이메일 인증 */}
+          <div className={cn('flex flex-col gap-2')}>
+            <p className={cn('text-foreground text-sm font-medium')}>이메일 인증</p>
+
+            <div className={cn('flex items-start gap-2')}>
+              <div className={cn('flex flex-1 flex-col gap-1.5')}>
+                <div className={cn('flex')}>
                   <Input
                     id="email"
                     type="text"
+                    aria-label="이메일"
+                    aria-invalid={!!errors.email}
                     placeholder="이메일을 입력하세요"
                     {...register('email')}
                     disabled={remainingTime > 0 || isCodeVerified}
-                    className={cn(
-                      'border-foreground focus-visible:border-foreground rounded-none focus-visible:ring-0',
-                    )}
+                    className={cn(FIELD_CLASS, 'flex-1')}
                   />
                   <span
                     className={cn(
-                      'border-foreground bg-muted text-muted-foreground flex h-9 items-center whitespace-nowrap border border-l-0 px-3 font-mono text-xs',
+                      'border-foreground bg-muted text-muted-foreground flex items-center whitespace-nowrap border border-l-0 px-3 font-mono text-sm',
                     )}
                   >
                     {EMAIL_DOMAIN}
                   </span>
                 </div>
-                <FormErrorMessage error={errors.email} />
+                <FormErrorMessage error={errors.email} className={cn(ERROR_MESSAGE_CLASS)} />
               </div>
+
               <button
                 type="button"
                 onClick={handleSendCode}
                 disabled={isButtonDisabled}
                 className={cn(
-                  'border-foreground bg-foreground text-background hover:bg-background hover:text-foreground h-9 flex-shrink-0 cursor-pointer border-2 px-3 font-mono text-xs uppercase tracking-wider transition-all disabled:cursor-not-allowed disabled:opacity-50',
+                  'border-foreground bg-foreground text-background hover:bg-background hover:text-foreground h-9 flex-shrink-0 cursor-pointer border px-3 font-mono text-xs tracking-[1.2px] transition-all disabled:cursor-not-allowed disabled:opacity-50',
                 )}
               >
                 {isSendingCode
@@ -278,127 +285,128 @@ const ResetPasswordForm = () => {
                     ? formatTime(remainingTime)
                     : codeSent && canResend
                       ? '재전송'
-                      : '인증코드'}
+                      : '코드전송'}
               </button>
             </div>
-          </div>
 
-          {/* Verification code */}
-          <div className={cn('space-y-1.5', !codeSent && 'cursor-not-allowed')}>
-            <Label
-              htmlFor="code"
-              className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
-            >
-              Verify Code
-            </Label>
-            <Input
-              id="code"
-              type="text"
-              placeholder="메일로 받은 인증 코드를 입력하세요"
-              {...register('code')}
-              disabled={!codeSent || isCodeVerified}
-              className={cn(
-                'border-foreground focus-visible:border-foreground rounded-none focus-visible:ring-0',
+            <div className={cn('flex flex-col gap-1.5')}>
+              <Input
+                id="code"
+                type="text"
+                aria-label="인증 코드"
+                aria-invalid={!!errors.code}
+                placeholder="인증 코드를 입력하세요"
+                {...register('code')}
+                disabled={!codeSent || isCodeVerified}
+                className={cn(FIELD_CLASS)}
+              />
+              {isCodeVerified ? (
+                <p
+                  className={cn(
+                    "text-xs leading-4 text-green-600 before:mr-1 before:content-['>']",
+                  )}
+                >
+                  인증 완료
+                </p>
+              ) : (
+                <FormErrorMessage error={errors.code} className={cn(ERROR_MESSAGE_CLASS)} />
               )}
-            />
-            {isCodeVerified ? (
-              <p className={cn('font-mono text-xs text-green-600')}>{'>'} 인증 완료</p>
-            ) : (
-              <FormErrorMessage error={errors.code} />
-            )}
+            </div>
           </div>
 
-          {/* New password */}
-          <div className={cn('space-y-1.5')}>
-            <Label
-              htmlFor="password"
-              className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
-            >
-              New Password
-            </Label>
-            <div className={cn('relative')}>
-              <Input
-                id="password"
-                type={showPassword ? 'text' : 'password'}
-                placeholder="새 비밀번호를 입력하세요"
-                {...register('password')}
-                disabled={!isCodeVerified || isChangingPassword}
-                className={cn(
-                  'border-foreground focus-visible:border-foreground rounded-none pr-10 focus-visible:ring-0',
-                )}
-              />
-              <button
-                type="button"
-                aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
-                onClick={() => setShowPassword(!showPassword)}
-                className={cn(
-                  'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
-                  (!isCodeVerified || isChangingPassword) && 'cursor-not-allowed opacity-50',
-                )}
-                disabled={!isCodeVerified || isChangingPassword}
-              >
-                {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-              </button>
-            </div>
-            <FormErrorMessage error={errors.password} />
-          </div>
+          {/* 새로운 비밀번호 */}
+          <div className={cn('flex flex-col gap-2')}>
+            <p className={cn('text-foreground text-sm font-medium')}>새로운 비밀번호</p>
 
-          {/* Confirm password */}
-          <div className={cn('space-y-1.5')}>
-            <Label
-              htmlFor="confirmPassword"
-              className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
-            >
-              Confirm Password
-            </Label>
-            <div className={cn('relative')}>
-              <Input
-                id="confirmPassword"
-                type={showConfirmPassword ? 'text' : 'password'}
-                placeholder="비밀번호를 다시 입력하세요"
-                {...register('confirmPassword')}
-                disabled={!isCodeVerified || isChangingPassword}
-                className={cn(
-                  'border-foreground focus-visible:border-foreground rounded-none pr-10 focus-visible:ring-0',
-                )}
-              />
-              <button
-                type="button"
-                aria-label={showConfirmPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
-                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                className={cn(
-                  'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
-                  (!isCodeVerified || isChangingPassword) && 'cursor-not-allowed opacity-50',
-                )}
-                disabled={!isCodeVerified || isChangingPassword}
-              >
-                {showConfirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-              </button>
+            <div className={cn('flex flex-col gap-1.5')}>
+              <div className={cn('relative')}>
+                <Input
+                  id="password"
+                  type={showPassword ? 'text' : 'password'}
+                  aria-label="새로운 비밀번호"
+                  aria-invalid={!!errors.password}
+                  placeholder="새로운 비밀번호를 입력하세요"
+                  {...register('password')}
+                  disabled={!isCodeVerified || isChangingPassword}
+                  className={cn(FIELD_CLASS, 'pr-10')}
+                />
+                <button
+                  type="button"
+                  aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+                  onClick={() => setShowPassword(!showPassword)}
+                  className={cn(
+                    'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
+                    (!isCodeVerified || isChangingPassword) && 'cursor-not-allowed opacity-50',
+                  )}
+                  disabled={!isCodeVerified || isChangingPassword}
+                >
+                  {showPassword ? (
+                    <EyeOff className={cn('size-4')} />
+                  ) : (
+                    <Eye className={cn('size-4')} />
+                  )}
+                </button>
+              </div>
+              <FormErrorMessage error={errors.password} className={cn(ERROR_MESSAGE_CLASS)} />
             </div>
-            <FormErrorMessage error={errors.confirmPassword} />
+
+            <div className={cn('flex flex-col gap-1.5')}>
+              <div className={cn('relative')}>
+                <Input
+                  id="confirmPassword"
+                  type={showConfirmPassword ? 'text' : 'password'}
+                  aria-label="비밀번호 확인"
+                  aria-invalid={!!errors.confirmPassword}
+                  placeholder="비밀번호를 다시 입력하세요"
+                  {...register('confirmPassword')}
+                  disabled={!isCodeVerified || isChangingPassword}
+                  className={cn(FIELD_CLASS, 'pr-10')}
+                />
+                <button
+                  type="button"
+                  aria-label={showConfirmPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  className={cn(
+                    'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
+                    (!isCodeVerified || isChangingPassword) && 'cursor-not-allowed opacity-50',
+                  )}
+                  disabled={!isCodeVerified || isChangingPassword}
+                >
+                  {showConfirmPassword ? (
+                    <EyeOff className={cn('size-4')} />
+                  ) : (
+                    <Eye className={cn('size-4')} />
+                  )}
+                </button>
+              </div>
+              <FormErrorMessage
+                error={errors.confirmPassword}
+                className={cn(ERROR_MESSAGE_CLASS)}
+              />
+            </div>
           </div>
         </div>
 
-        <div className={cn('space-y-3 px-6 pb-6 pt-5')}>
+        <div className={cn('flex flex-col items-center gap-4 p-5')}>
           <button
             type="submit"
             className={cn(
-              'border-foreground bg-foreground text-background hover:bg-background hover:text-foreground w-full cursor-pointer border-2 py-3 font-mono text-xs font-bold uppercase tracking-widest transition-all disabled:cursor-not-allowed disabled:opacity-60',
+              'border-foreground bg-foreground text-background hover:bg-background hover:text-foreground w-full cursor-pointer border-2 py-3 font-mono text-xs font-bold uppercase tracking-[1.2px] transition-all disabled:cursor-not-allowed disabled:opacity-60',
             )}
             disabled={isChangingPassword || !isCodeVerified || !isFormValid}
           >
             {isChangingPassword ? 'PROCESSING...' : 'RESET PASSWORD'}
           </button>
 
-          <p className={cn('text-muted-foreground text-center text-xs')}>
-            <button
-              type="button"
-              onClick={() => window.close()}
-              className={cn('text-foreground font-semibold underline underline-offset-2')}
-            >
-              창을 닫고 로그인으로 돌아가기
-            </button>
-          </p>
+          <button
+            type="button"
+            onClick={() => window.close()}
+            className={cn(
+              'text-foreground cursor-pointer text-xs leading-4 underline underline-offset-2',
+            )}
+          >
+            비밀번호가 기억나셨나요?
+          </button>
         </div>
       </form>
     </div>

--- a/apps/oauth/src/widgets/signup/index.ts
+++ b/apps/oauth/src/widgets/signup/index.ts
@@ -2,3 +2,4 @@ export { default as SignUpForm } from './ui/SignUpForm';
 export * from './model/useSendEmailCode';
 export * from './model/useCheckEmailCode';
 export * from './model/useSignUp';
+export * from './model/useEmailVerification';

--- a/apps/oauth/src/widgets/signup/model/useEmailVerification.ts
+++ b/apps/oauth/src/widgets/signup/model/useEmailVerification.ts
@@ -1,0 +1,136 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { getApiErrorCode, minutesToMs } from '@repo/shared/utils';
+import { toast } from 'sonner';
+
+import { useCheckEmailCode } from './useCheckEmailCode';
+import { useSendEmailCode } from './useSendEmailCode';
+
+const RESEND_COOLDOWN_MS = minutesToMs(5);
+const STORAGE_KEY = 'email_verification_timestamp';
+
+interface UseEmailVerificationParams {
+  /** 인증 시간이 만료돼 코드가 무효해졌을 때 호출됩니다. (입력값 초기화용) */
+  onCodeExpired?: () => void;
+}
+
+/**
+ * 회원가입 이메일 인증 상태를 관리합니다.
+ * 코드 전송 후 5분 재전송 쿨다운을 localStorage에 남겨 새로고침에도 유지합니다.
+ */
+export const useEmailVerification = ({ onCodeExpired }: UseEmailVerificationParams = {}) => {
+  const [codeSent, setCodeSent] = useState(false);
+  const [isCodeVerified, setIsCodeVerified] = useState(false);
+  const [remainingTime, setRemainingTime] = useState(0);
+
+  const hasShownExpiredToast = useRef(false);
+  const onCodeExpiredRef = useRef(onCodeExpired);
+  onCodeExpiredRef.current = onCodeExpired;
+
+  useEffect(() => {
+    const lastSentTime = localStorage.getItem(STORAGE_KEY);
+    if (!lastSentTime) return;
+
+    const elapsed = Date.now() - parseInt(lastSentTime, 10);
+    if (elapsed < RESEND_COOLDOWN_MS) {
+      setCodeSent(true);
+      setRemainingTime(Math.ceil((RESEND_COOLDOWN_MS - elapsed) / 1000));
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (remainingTime <= 0) return;
+
+    const timer = setInterval(() => {
+      setRemainingTime((prev) => {
+        if (prev > 1) return prev - 1;
+
+        localStorage.removeItem(STORAGE_KEY);
+        setCodeSent(false);
+        setIsCodeVerified((verified) => {
+          if (verified) return verified;
+
+          onCodeExpiredRef.current?.();
+          if (!hasShownExpiredToast.current) {
+            hasShownExpiredToast.current = true;
+            toast.error('인증 시간이 만료되었습니다. 다시 인증해주세요.');
+          }
+          return false;
+        });
+        return 0;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [remainingTime]);
+
+  const { mutate: sendEmailCode, isPending: isSendingCode } = useSendEmailCode({
+    onSuccess: () => {
+      localStorage.setItem(STORAGE_KEY, Date.now().toString());
+      setCodeSent(true);
+      setRemainingTime(RESEND_COOLDOWN_MS / 1000);
+      hasShownExpiredToast.current = false;
+      toast.success('인증 코드가 이메일로 전송되었습니다.');
+    },
+    onError: (error: unknown) => {
+      switch (getApiErrorCode(error)) {
+        case 400:
+          toast.error('이메일 형식을 확인해주세요.');
+          break;
+        case 409:
+          toast.error('이미 해당 이메일을 가진 계정이 존재합니다.');
+          break;
+        default:
+          toast.error('인증 코드 전송에 실패했습니다.');
+      }
+    },
+  });
+
+  const { mutate: checkEmailCode } = useCheckEmailCode({
+    onSuccess: () => {
+      setIsCodeVerified(true);
+      toast.success('인증 코드가 확인되었습니다.');
+    },
+    onError: (error: unknown) => {
+      setIsCodeVerified(false);
+      switch (getApiErrorCode(error)) {
+        case 400:
+          toast.error('인증 코드가 일치하지 않습니다.');
+          break;
+        case 404:
+          toast.error('인증 코드가 만료되었거나 존재하지 않습니다.');
+          break;
+        default:
+          toast.error('인증 코드 확인에 실패했습니다.');
+      }
+    },
+  });
+
+  const sendCode = useCallback(
+    (email: string) => {
+      sendEmailCode({ email });
+    },
+    [sendEmailCode],
+  );
+
+  const verifyCode = useCallback(
+    (email: string, code: string) => {
+      checkEmailCode({ email, code });
+    },
+    [checkEmailCode],
+  );
+
+  return {
+    codeSent,
+    isCodeVerified,
+    remainingTime,
+    isSendingCode,
+    canResend: remainingTime === 0,
+    sendCode,
+    verifyCode,
+  };
+};

--- a/apps/oauth/src/widgets/signup/ui/SignUpForm/index.tsx
+++ b/apps/oauth/src/widgets/signup/ui/SignUpForm/index.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -15,7 +16,6 @@ import {
   DialogTitle,
   FormErrorMessage,
   Input,
-  Label,
   Select,
   SelectContent,
   SelectItem,
@@ -23,34 +23,39 @@ import {
   SelectValue,
   Textarea,
 } from '@repo/shared/ui';
-import { cn, formatEmailWithDomain, getApiErrorCode, minutesToMs } from '@repo/shared/utils';
+import { cn, formatEmailWithDomain, getApiErrorCode } from '@repo/shared/utils';
 import { Eye, EyeOff } from 'lucide-react';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 
 import {
-  SignUpFormSchema,
   SignUpFormType,
+  SignUpObjectType,
   TEACHER_DEPARTMENT_OPTIONS,
+  getSignUpFormSchema,
   getTeacherDepartmentLabel,
 } from '@/entities/signup';
-import { useCheckEmailCode, useSendEmailCode, useSignUp } from '@/widgets/signup';
+import { useEmailVerification, useSignUp } from '@/widgets/signup';
 
 import { PRIVACY_POLICY } from '../../constants/privacyPolicy';
 
-const RESEND_COOLDOWN_MS = minutesToMs(5);
-const STORAGE_KEY = 'email_verification_timestamp';
+const ERROR_MESSAGE_CLASS = "text-destructive text-xs leading-4 before:mr-1 before:content-['>']";
+const FIELD_CLASS =
+  'border-foreground focus-visible:border-foreground aria-invalid:border-destructive aria-invalid:text-destructive rounded-none focus-visible:ring-0';
 
-const SignUpForm = () => {
-  const [codeSent, setCodeSent] = useState(false);
-  const [isCodeVerified, setIsCodeVerified] = useState(false);
-  const [remainingTime, setRemainingTime] = useState(0);
+interface SignUpFormProps {
+  objectType?: SignUpObjectType;
+}
+
+const SignUpForm = ({ objectType = 'STUDENT' }: SignUpFormProps) => {
   const [isPrivacyDialogOpen, setIsPrivacyDialogOpen] = useState(false);
   const [hasScrolledToBottom, setHasScrolledToBottom] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
+
+  const isTeacher = objectType === 'TEACHER';
 
   const {
     register,
@@ -61,11 +66,9 @@ const SignUpForm = () => {
     watch,
     setValue,
     control,
-    resetField,
   } = useForm<SignUpFormType>({
-    resolver: zodResolver(SignUpFormSchema),
+    resolver: zodResolver(getSignUpFormSchema(objectType)),
     defaultValues: {
-      objectType: 'STUDENT',
       email: '',
       password: '',
       confirmPassword: '',
@@ -74,22 +77,25 @@ const SignUpForm = () => {
     },
   });
 
-  const objectTypeValue = watch('objectType');
   const codeValue = watch('code');
   const emailValue = watch('email');
   const debouncedCode = useDebounce(codeValue, 1000);
   const lastCheckedCode = useRef('');
-  const hasShownExpiredToast = useRef(false);
 
-  const isTeacher = objectTypeValue === 'TEACHER';
-
-  const handleObjectTypeChange = (nextType: SignUpFormType['objectType']) => {
-    if (nextType === objectTypeValue) return;
-    setValue('objectType', nextType);
-    resetField('name');
-    resetField('department');
-    resetField('description');
-  };
+  const {
+    codeSent,
+    isCodeVerified,
+    remainingTime,
+    isSendingCode,
+    canResend,
+    sendCode,
+    verifyCode,
+  } = useEmailVerification({
+    onCodeExpired: () => {
+      lastCheckedCode.current = '';
+      setValue('code', '');
+    },
+  });
 
   const handlePrivacyCheckboxClick = () => {
     const isAgreed = getValues('privacyAgreed');
@@ -123,91 +129,6 @@ const SignUpForm = () => {
   }, [isPrivacyDialogOpen]);
 
   useEffect(() => {
-    const lastSentTime = localStorage.getItem(STORAGE_KEY);
-    if (lastSentTime) {
-      const elapsed = Date.now() - parseInt(lastSentTime, 10);
-      if (elapsed < RESEND_COOLDOWN_MS) {
-        setCodeSent(true);
-        setRemainingTime(Math.ceil((RESEND_COOLDOWN_MS - elapsed) / 1000));
-      } else {
-        localStorage.removeItem(STORAGE_KEY);
-      }
-    }
-  }, []);
-
-  useEffect(() => {
-    if (remainingTime > 0) {
-      const timer = setInterval(() => {
-        setRemainingTime((prev) => {
-          if (prev === 1) {
-            localStorage.removeItem(STORAGE_KEY);
-            setCodeSent(false);
-            if (!isCodeVerified) {
-              setIsCodeVerified(false);
-              lastCheckedCode.current = '';
-              setValue('code', '');
-              if (!hasShownExpiredToast.current) {
-                hasShownExpiredToast.current = true;
-                toast.error('인증 시간이 만료되었습니다. 다시 인증해주세요.');
-              }
-            }
-            return 0;
-          }
-          return prev - 1;
-        });
-      }, 1000);
-      return () => clearInterval(timer);
-    }
-  }, [remainingTime, setValue, isCodeVerified]);
-
-  const { mutate: sendEmailCode, isPending: isSendingCode } = useSendEmailCode({
-    onSuccess: () => {
-      const timestamp = Date.now();
-      localStorage.setItem(STORAGE_KEY, timestamp.toString());
-      setCodeSent(true);
-      setRemainingTime(RESEND_COOLDOWN_MS / 1000);
-      hasShownExpiredToast.current = false;
-      toast.success('인증 코드가 이메일로 전송되었습니다.');
-    },
-    onError: (error: unknown) => {
-      const statusCode = getApiErrorCode(error);
-      switch (statusCode) {
-        case 400:
-          toast.error('이메일 형식을 확인해주세요.');
-          break;
-        case 409:
-          toast.error('이미 해당 이메일을 가진 계정이 존재합니다.');
-          break;
-        default:
-          toast.error('인증 코드 전송에 실패했습니다.');
-      }
-    },
-  });
-
-  const { mutate: checkEmailCode } = useCheckEmailCode({
-    onSuccess: () => {
-      setIsCodeVerified(true);
-      toast.success('인증 코드가 확인되었습니다.');
-    },
-    onError: (error: unknown) => {
-      const statusCode = getApiErrorCode(error);
-      switch (statusCode) {
-        case 400:
-          setIsCodeVerified(false);
-          toast.error('인증 코드가 일치하지 않습니다.');
-          break;
-        case 404:
-          setIsCodeVerified(false);
-          toast.error('인증 코드가 만료되었거나 존재하지 않습니다.');
-          break;
-        default:
-          setIsCodeVerified(false);
-          toast.error('인증 코드 확인에 실패했습니다.');
-      }
-    },
-  });
-
-  useEffect(() => {
     if (
       codeSent &&
       debouncedCode &&
@@ -215,20 +136,16 @@ const SignUpForm = () => {
       lastCheckedCode.current !== debouncedCode
     ) {
       lastCheckedCode.current = debouncedCode;
-      checkEmailCode({
-        email: formatEmailWithDomain(emailValue),
-        code: debouncedCode,
-      });
+      verifyCode(formatEmailWithDomain(emailValue), debouncedCode);
     }
-  }, [codeSent, debouncedCode, emailValue, checkEmailCode]);
+  }, [codeSent, debouncedCode, emailValue, verifyCode]);
 
   const { mutate: signUp, isPending: isSigningUp } = useSignUp({
     onSuccess: () => {
       router.push(isTeacher ? '/success?page=signup-teacher' : '/success?page=signup');
     },
     onError: (error: unknown) => {
-      const statusCode = getApiErrorCode(error);
-      switch (statusCode) {
+      switch (getApiErrorCode(error)) {
         case 400:
           toast.error('입력 데이터를 확인해주세요.');
           break;
@@ -251,8 +168,7 @@ const SignUpForm = () => {
   const handleSendCode = async () => {
     const isEmailValid = await trigger('email');
     if (!isEmailValid) return;
-    const email = getValues('email');
-    sendEmailCode({ email: formatEmailWithDomain(email) });
+    sendCode(formatEmailWithDomain(getValues('email')));
   };
 
   const formatTime = (seconds: number) => {
@@ -261,8 +177,7 @@ const SignUpForm = () => {
     return `${mins}:${secs.toString().padStart(2, '0')}`;
   };
 
-  const canResend = remainingTime === 0;
-  const isButtonDisabled =
+  const isSendCodeDisabled =
     isSendingCode || !emailValue || (codeSent && !canResend) || isCodeVerified;
 
   const onSubmit: SubmitHandler<SignUpFormType> = (data) => {
@@ -270,12 +185,12 @@ const SignUpForm = () => {
       toast.error('이메일 인증을 완료해주세요.');
       return;
     }
-    const { objectType, email, password, code, name, department, description } = data;
+    const { email, password, code, name, department, description } = data;
 
-    if (objectType === 'TEACHER') {
+    if (isTeacher) {
       if (!name?.trim() || !department) return;
       signUp({
-        objectType,
+        objectType: 'TEACHER',
         email: formatEmailWithDomain(email),
         password,
         code,
@@ -291,104 +206,71 @@ const SignUpForm = () => {
 
   return (
     <>
-      <div
-        className={cn('border-foreground bg-background pixel-shadow-lg w-full max-w-md border-2')}
-      >
+      <div className={cn('border-foreground bg-background max-w-100 w-full border-2')}>
         {/* Title bar */}
         <div
           className={cn(
-            'border-foreground bg-foreground flex items-center gap-3 border-b-2 px-5 py-3',
+            'border-foreground bg-foreground flex items-center gap-3 border-b-2 px-4 py-3',
           )}
         >
           <div
             className={cn(
-              'bg-background text-foreground font-pixel flex h-6 w-6 flex-shrink-0 items-center justify-center text-[8px]',
+              'bg-background text-foreground font-pixel flex size-6 flex-shrink-0 items-center justify-center text-[8px]',
             )}
           >
             D
           </div>
           <span className={cn('text-background font-pixel text-[9px]')}>DataGSM</span>
+          <span className={cn('text-background font-pixel text-[9px]')}>Sign Up</span>
         </div>
 
         {/* Header */}
-        <div className={cn('border-border/50 border-b px-6 py-5')}>
-          <h1 className={cn('text-foreground text-xl font-bold')}>회원가입</h1>
-          <p className={cn('text-muted-foreground mt-1 text-sm')}>
-            @gsm.hs.kr 도메인 계정만 사용 가능합니다
+        <div className={cn('border-border/50 flex flex-col gap-2 border-b p-5')}>
+          <h1 className={cn('text-foreground text-xl font-semibold leading-[1.45]')}>
+            {isTeacher ? '선생님 회원가입' : '회원가입'}
+          </h1>
+          <p className={cn('text-muted-foreground text-xs leading-[18px]')}>
+            <span className={cn('font-mono font-bold')}>{EMAIL_DOMAIN}</span> 도메인 계정만 사용
+            가능합니다.
           </p>
         </div>
 
         <form onSubmit={handleSubmit(onSubmit)}>
-          <div className={cn('space-y-4 px-6 pt-5')}>
-            {/* Account type */}
-            <div className={cn('space-y-1.5')}>
-              <Label
-                className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
-              >
-                가입 종류
-              </Label>
-              <div className={cn('grid grid-cols-2 gap-2')}>
-                {(['STUDENT', 'TEACHER'] as const).map((type) => (
-                  <button
-                    key={type}
-                    type="button"
-                    onClick={() => handleObjectTypeChange(type)}
-                    aria-pressed={objectTypeValue === type}
-                    className={cn(
-                      'border-foreground cursor-pointer border-2 py-2.5 font-mono text-xs font-bold uppercase tracking-widest transition-all',
-                      objectTypeValue === type
-                        ? 'bg-foreground text-background'
-                        : 'bg-background text-foreground hover:bg-foreground/10',
-                    )}
-                  >
-                    {type === 'STUDENT' ? '학생' : '선생님'}
-                  </button>
-                ))}
-              </div>
-              {isTeacher && (
-                <p className={cn('text-muted-foreground font-mono text-xs')}>
-                  {'>'} 선생님 계정은 관리자 승인 후 사용할 수 있습니다
-                </p>
-              )}
-            </div>
+          <div className={cn('flex flex-col gap-5 px-5 pt-5')}>
+            {/* 이메일 인증 */}
+            <div className={cn('flex flex-col gap-2')}>
+              <p className={cn('text-foreground text-sm font-medium')}>이메일 인증</p>
 
-            {/* Email + code send */}
-            <div className={cn('space-y-1.5')}>
-              <Label
-                htmlFor="email"
-                className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
-              >
-                Email
-              </Label>
-              <div className={cn('flex gap-2')}>
-                <div className={cn('flex-1 space-y-1')}>
-                  <div className={cn('flex items-center')}>
+              <div className={cn('flex items-start gap-2')}>
+                <div className={cn('flex flex-1 flex-col gap-1.5')}>
+                  <div className={cn('flex')}>
                     <Input
                       id="email"
                       type="text"
-                      placeholder="이메일을 입력하세요"
+                      aria-label="이메일"
+                      aria-invalid={!!errors.email}
+                      placeholder="이메일을 입력해주세요"
                       {...register('email')}
                       disabled={remainingTime > 0 || isCodeVerified}
-                      className={cn(
-                        'border-foreground focus-visible:border-foreground rounded-none focus-visible:ring-0',
-                      )}
+                      className={cn(FIELD_CLASS, 'flex-1')}
                     />
                     <span
                       className={cn(
-                        'border-foreground bg-muted text-muted-foreground flex h-9 items-center whitespace-nowrap border border-l-0 px-3 font-mono text-xs',
+                        'border-foreground bg-muted text-muted-foreground flex items-center whitespace-nowrap border border-l-0 px-3 font-mono text-sm',
                       )}
                     >
                       {EMAIL_DOMAIN}
                     </span>
                   </div>
-                  <FormErrorMessage error={errors.email} />
+                  <FormErrorMessage error={errors.email} className={cn(ERROR_MESSAGE_CLASS)} />
                 </div>
+
                 <button
                   type="button"
                   onClick={handleSendCode}
-                  disabled={isButtonDisabled}
+                  disabled={isSendCodeDisabled}
                   className={cn(
-                    'border-foreground bg-foreground text-background hover:bg-background hover:text-foreground h-9 flex-shrink-0 cursor-pointer border-2 px-3 font-mono text-xs uppercase tracking-wider transition-all disabled:cursor-not-allowed disabled:opacity-50',
+                    'border-foreground bg-foreground text-background hover:bg-background hover:text-foreground h-9 flex-shrink-0 cursor-pointer border px-3 font-mono text-xs tracking-[1.2px] transition-all disabled:cursor-not-allowed disabled:opacity-50',
                   )}
                 >
                   {isSendingCode
@@ -397,144 +279,127 @@ const SignUpForm = () => {
                       ? formatTime(remainingTime)
                       : codeSent && canResend
                         ? '재전송'
-                        : '인증코드'}
+                        : '코드전송'}
                 </button>
               </div>
-            </div>
 
-            {/* Verification code */}
-            <div className={cn('space-y-1.5', !codeSent && 'cursor-not-allowed')}>
-              <Label
-                htmlFor="code"
-                className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
-              >
-                Verify Code
-              </Label>
-              <Input
-                id="code"
-                type="text"
-                placeholder="메일로 받은 인증 코드를 입력하세요"
-                {...register('code')}
-                disabled={!codeSent || isCodeVerified}
-                className={cn(
-                  'border-foreground focus-visible:border-foreground rounded-none focus-visible:ring-0',
-                )}
-              />
-              {isCodeVerified ? (
-                <p className={cn('font-mono text-xs text-green-600')}>{'>'} 인증 완료</p>
-              ) : (
-                <FormErrorMessage error={errors.code} />
-              )}
-            </div>
-
-            {/* Password */}
-            <div className={cn('space-y-1.5')}>
-              <Label
-                htmlFor="password"
-                className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
-              >
-                Password
-              </Label>
-              <div className={cn('relative')}>
+              <div className={cn('flex flex-col gap-1.5')}>
                 <Input
-                  id="password"
-                  type={showPassword ? 'text' : 'password'}
-                  placeholder="비밀번호를 입력하세요"
-                  {...register('password')}
-                  disabled={!isCodeVerified || isSigningUp}
-                  className={cn(
-                    'border-foreground focus-visible:border-foreground rounded-none pr-10 focus-visible:ring-0',
-                  )}
+                  id="code"
+                  type="text"
+                  aria-label="인증 코드"
+                  aria-invalid={!!errors.code}
+                  placeholder="인증 코드를 입력해주세요"
+                  {...register('code')}
+                  disabled={!codeSent || isCodeVerified}
+                  className={cn(FIELD_CLASS)}
                 />
-                <button
-                  type="button"
-                  aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
-                  onClick={() => setShowPassword(!showPassword)}
-                  className={cn(
-                    'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
-                    (!isCodeVerified || isSigningUp) && 'cursor-not-allowed opacity-50',
-                  )}
-                  disabled={!isCodeVerified || isSigningUp}
-                >
-                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </button>
-              </div>
-              <FormErrorMessage error={errors.password} />
-            </div>
-
-            {/* Confirm password */}
-            <div className={cn('space-y-1.5')}>
-              <Label
-                htmlFor="confirmPassword"
-                className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
-              >
-                Confirm Password
-              </Label>
-              <div className={cn('relative')}>
-                <Input
-                  id="confirmPassword"
-                  type={showConfirmPassword ? 'text' : 'password'}
-                  placeholder="비밀번호를 다시 입력하세요"
-                  {...register('confirmPassword')}
-                  disabled={!isCodeVerified || isSigningUp}
-                  className={cn(
-                    'border-foreground focus-visible:border-foreground rounded-none pr-10 focus-visible:ring-0',
-                  )}
-                />
-                <button
-                  type="button"
-                  aria-label={showConfirmPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
-                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                  className={cn(
-                    'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
-                    (!isCodeVerified || isSigningUp) && 'cursor-not-allowed opacity-50',
-                  )}
-                  disabled={!isCodeVerified || isSigningUp}
-                >
-                  {showConfirmPassword ? (
-                    <EyeOff className="h-4 w-4" />
-                  ) : (
-                    <Eye className="h-4 w-4" />
-                  )}
-                </button>
-              </div>
-              <FormErrorMessage error={errors.confirmPassword} />
-            </div>
-
-            {/* Teacher info */}
-            {isTeacher && (
-              <>
-                <div className={cn('space-y-1.5')}>
-                  <Label
-                    htmlFor="name"
+                {isCodeVerified ? (
+                  <p
                     className={cn(
-                      'text-muted-foreground font-mono text-xs uppercase tracking-widest',
+                      "text-xs leading-4 text-green-600 before:mr-1 before:content-['>']",
                     )}
                   >
-                    성함
-                  </Label>
+                    인증 완료
+                  </p>
+                ) : (
+                  <FormErrorMessage error={errors.code} className={cn(ERROR_MESSAGE_CLASS)} />
+                )}
+              </div>
+            </div>
+
+            {/* 비밀번호 */}
+            <div className={cn('flex flex-col gap-2')}>
+              <p className={cn('text-foreground text-sm font-medium')}>비밀번호</p>
+
+              <div className={cn('flex flex-col gap-1.5')}>
+                <div className={cn('relative')}>
+                  <Input
+                    id="password"
+                    type={showPassword ? 'text' : 'password'}
+                    aria-label="비밀번호"
+                    aria-invalid={!!errors.password}
+                    placeholder="비밀번호를 입력해주세요"
+                    {...register('password')}
+                    disabled={!isCodeVerified || isSigningUp}
+                    className={cn(FIELD_CLASS, 'pr-10')}
+                  />
+                  <button
+                    type="button"
+                    aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+                    onClick={() => setShowPassword(!showPassword)}
+                    className={cn(
+                      'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
+                      (!isCodeVerified || isSigningUp) && 'cursor-not-allowed opacity-50',
+                    )}
+                    disabled={!isCodeVerified || isSigningUp}
+                  >
+                    {showPassword ? (
+                      <EyeOff className={cn('size-4')} />
+                    ) : (
+                      <Eye className={cn('size-4')} />
+                    )}
+                  </button>
+                </div>
+                <FormErrorMessage error={errors.password} className={cn(ERROR_MESSAGE_CLASS)} />
+              </div>
+
+              <div className={cn('flex flex-col gap-1.5')}>
+                <div className={cn('relative')}>
+                  <Input
+                    id="confirmPassword"
+                    type={showConfirmPassword ? 'text' : 'password'}
+                    aria-label="비밀번호 확인"
+                    aria-invalid={!!errors.confirmPassword}
+                    placeholder="비밀번호를 다시 입력해주세요"
+                    {...register('confirmPassword')}
+                    disabled={!isCodeVerified || isSigningUp}
+                    className={cn(FIELD_CLASS, 'pr-10')}
+                  />
+                  <button
+                    type="button"
+                    aria-label={showConfirmPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    className={cn(
+                      'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
+                      (!isCodeVerified || isSigningUp) && 'cursor-not-allowed opacity-50',
+                    )}
+                    disabled={!isCodeVerified || isSigningUp}
+                  >
+                    {showConfirmPassword ? (
+                      <EyeOff className={cn('size-4')} />
+                    ) : (
+                      <Eye className={cn('size-4')} />
+                    )}
+                  </button>
+                </div>
+                <FormErrorMessage
+                  error={errors.confirmPassword}
+                  className={cn(ERROR_MESSAGE_CLASS)}
+                />
+              </div>
+            </div>
+
+            {/* 선생님 정보 */}
+            {isTeacher && (
+              <div className={cn('flex flex-col gap-2')}>
+                <p className={cn('text-foreground text-sm font-medium')}>선생님 정보</p>
+
+                <div className={cn('flex flex-col gap-1.5')}>
                   <Input
                     id="name"
                     type="text"
-                    placeholder="성함을 입력하세요"
+                    aria-label="성함"
+                    aria-invalid={!!errors.name}
+                    placeholder="성함을 입력해주세요"
                     {...register('name')}
                     disabled={!isCodeVerified || isSigningUp}
-                    className={cn(
-                      'border-foreground focus-visible:border-foreground rounded-none focus-visible:ring-0',
-                    )}
+                    className={cn(FIELD_CLASS)}
                   />
-                  <FormErrorMessage error={errors.name} />
+                  <FormErrorMessage error={errors.name} className={cn(ERROR_MESSAGE_CLASS)} />
                 </div>
 
-                <div className={cn('space-y-1.5')}>
-                  <Label
-                    htmlFor="department"
-                    className={cn(
-                      'text-muted-foreground font-mono text-xs uppercase tracking-widest',
-                    )}
-                  >
-                    소속 부서
-                  </Label>
+                <div className={cn('flex flex-col gap-1.5')}>
                   <Controller
                     control={control}
                     name="department"
@@ -546,9 +411,13 @@ const SignUpForm = () => {
                       >
                         <SelectTrigger
                           id="department"
-                          className={cn('border-foreground w-full rounded-none')}
+                          aria-label="소속 부서"
+                          aria-invalid={!!errors.department}
+                          className={cn(
+                            'border-foreground aria-invalid:border-destructive w-full rounded-none',
+                          )}
                         >
-                          <SelectValue placeholder="소속 부서를 선택하세요" />
+                          <SelectValue placeholder="소속 부서를 선택해주세요" />
                         </SelectTrigger>
                         <SelectContent>
                           {TEACHER_DEPARTMENT_OPTIONS.map((department) => (
@@ -560,65 +429,71 @@ const SignUpForm = () => {
                       </Select>
                     )}
                   />
-                  <FormErrorMessage error={errors.department} />
+                  <FormErrorMessage error={errors.department} className={cn(ERROR_MESSAGE_CLASS)} />
                 </div>
 
-                <div className={cn('space-y-1.5')}>
-                  <Label
-                    htmlFor="description"
-                    className={cn(
-                      'text-muted-foreground font-mono text-xs uppercase tracking-widest',
-                    )}
-                  >
-                    설명 (선택)
-                  </Label>
+                <div className={cn('flex flex-col gap-1.5')}>
                   <Textarea
                     id="description"
-                    placeholder="예: 3학년 1반 담임선생님"
+                    aria-label="설명"
+                    aria-invalid={!!errors.description}
+                    placeholder="설명을 입력해주세요 (예: 3학년 1반 담임선생님)"
                     {...register('description')}
                     disabled={!isCodeVerified || isSigningUp}
-                    className={cn(
-                      'border-foreground focus-visible:border-foreground rounded-none focus-visible:ring-0',
-                    )}
+                    className={cn(FIELD_CLASS, 'h-[72px] resize-none')}
                   />
-                  <FormErrorMessage error={errors.description} />
+                  <FormErrorMessage
+                    error={errors.description}
+                    className={cn(ERROR_MESSAGE_CLASS)}
+                  />
                 </div>
-              </>
+              </div>
             )}
-
-            {/* Privacy */}
-            <div className={cn('flex items-center gap-2')}>
-              <Checkbox
-                id="privacy"
-                checked={watch('privacyAgreed')}
-                onCheckedChange={handlePrivacyCheckboxClick}
-              />
-              <label
-                htmlFor="privacy"
-                className={cn('cursor-pointer text-sm leading-none')}
-                onClick={(e) => {
-                  e.preventDefault();
-                  handlePrivacyCheckboxClick();
-                }}
-              >
-                <span className={cn('font-medium underline underline-offset-2 hover:opacity-70')}>
-                  개인정보 처리방침
-                </span>
-                에 동의합니다
-              </label>
-            </div>
           </div>
 
-          <div className={cn('space-y-3 px-6 pb-6 pt-5')}>
+          <div className={cn('flex flex-col items-center gap-4 p-5')}>
+            {/* Privacy */}
+            <div className={cn('flex w-full flex-col gap-1.5')}>
+              <div className={cn('flex items-center gap-2')}>
+                <Checkbox
+                  id="privacy"
+                  checked={watch('privacyAgreed')}
+                  onCheckedChange={handlePrivacyCheckboxClick}
+                  aria-invalid={!!errors.privacyAgreed}
+                />
+                <label
+                  htmlFor="privacy"
+                  className={cn('text-muted-foreground cursor-pointer text-sm leading-none')}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    handlePrivacyCheckboxClick();
+                  }}
+                >
+                  <span className={cn('text-foreground font-medium underline underline-offset-2')}>
+                    개인정보 처리방침
+                  </span>
+                  에 동의합니다
+                </label>
+              </div>
+              <FormErrorMessage error={errors.privacyAgreed} className={cn(ERROR_MESSAGE_CLASS)} />
+            </div>
+
             <button
               type="submit"
               className={cn(
-                'border-foreground bg-foreground text-background hover:bg-background hover:text-foreground w-full cursor-pointer border-2 py-3 font-mono text-xs font-bold uppercase tracking-widest transition-all disabled:cursor-not-allowed disabled:opacity-60',
+                'border-foreground bg-foreground text-background hover:bg-background hover:text-foreground w-full cursor-pointer border-2 py-3 font-mono text-xs font-bold uppercase tracking-[1.2px] transition-all disabled:cursor-not-allowed disabled:opacity-60',
               )}
               disabled={isSigningUp || !isCodeVerified}
             >
-              {isSigningUp ? 'PROCESSING...' : isTeacher ? '회원가입 신청' : 'SIGN UP'}
+              {isSigningUp ? 'PROCESSING...' : 'SIGN UP'}
             </button>
+
+            <Link
+              href={isTeacher ? '/signup' : '/signup/teacher'}
+              className={cn('text-foreground text-xs leading-4 underline underline-offset-2')}
+            >
+              {isTeacher ? '학생으로 회원가입하나요?' : '선생님으로 회원가입하시나요?'}
+            </Link>
 
             <p className={cn('text-muted-foreground text-center text-xs')}>
               이미 계정이 있으신가요?{' '}

--- a/apps/oauth/src/widgets/signup/ui/SignUpForm/index.tsx
+++ b/apps/oauth/src/widgets/signup/ui/SignUpForm/index.tsx
@@ -11,6 +11,7 @@ import { useDebounce } from '@repo/shared/hooks';
 import {
   Checkbox,
   Dialog,
+  DialogClose,
   DialogContent,
   DialogHeader,
   DialogTitle,
@@ -501,25 +502,38 @@ const SignUpForm = ({ objectType = 'STUDENT' }: SignUpFormProps) => {
       {/* Privacy dialog */}
       <Dialog open={isPrivacyDialogOpen} onOpenChange={setIsPrivacyDialogOpen}>
         <DialogContent
+          showCloseButton={false}
           className={cn(
-            'border-foreground pixel-shadow flex max-h-[80vh] max-w-md flex-col border-2',
+            'border-foreground sm:max-w-160 flex max-h-[80vh] flex-col gap-0 border-2 p-0',
           )}
         >
-          <DialogHeader>
-            <DialogTitle className={cn('text-base font-bold')}>개인정보 처리방침</DialogTitle>
+          <DialogHeader
+            className={cn('bg-foreground flex-row items-center justify-between gap-3 px-4 py-3')}
+          >
+            <DialogTitle className={cn('text-background font-pixel text-[9px] font-normal')}>
+              privacy policy
+            </DialogTitle>
+            <DialogClose
+              aria-label="닫기"
+              className={cn(
+                'border-background/30 text-background hover:bg-background hover:text-foreground flex h-6 cursor-pointer items-center justify-center border px-2 font-mono text-xs tracking-[1.2px] transition-all',
+              )}
+            >
+              X
+            </DialogClose>
           </DialogHeader>
           <div
             ref={scrollRef}
             onScroll={handleScroll}
-            className={cn('max-w-none flex-1 overflow-y-auto pr-4')}
+            className={cn('max-w-none flex-1 overflow-y-auto px-5 pt-4')}
           >
-            <div className={cn('whitespace-pre-wrap text-sm leading-relaxed')}>
+            <div className={cn('text-muted-foreground whitespace-pre-wrap text-[13px]')}>
               {PRIVACY_POLICY.split('\n').map((line, index) => {
                 if (line.startsWith('# ')) {
                   return (
                     <h1
                       key={index}
-                      className={cn('mb-2 mt-4 text-xl font-bold')}
+                      className={cn('text-foreground mb-1 text-base font-semibold leading-[1.45]')}
                       dangerouslySetInnerHTML={{ __html: line.replace('# ', '') }}
                     />
                   );
@@ -528,7 +542,7 @@ const SignUpForm = ({ objectType = 'STUDENT' }: SignUpFormProps) => {
                   return (
                     <h2
                       key={index}
-                      className={cn('mb-2 mt-4 text-lg font-semibold')}
+                      className={cn('text-foreground mb-1 mt-4 text-sm font-medium')}
                       dangerouslySetInnerHTML={{ __html: line.replace('## ', '') }}
                     />
                   );
@@ -537,7 +551,7 @@ const SignUpForm = ({ objectType = 'STUDENT' }: SignUpFormProps) => {
                   return (
                     <h3
                       key={index}
-                      className={cn('mb-1 mt-3 text-base font-medium')}
+                      className={cn('text-foreground mt-2 text-sm font-medium')}
                       dangerouslySetInnerHTML={{ __html: line.replace('### ', '') }}
                     />
                   );
@@ -548,18 +562,16 @@ const SignUpForm = ({ objectType = 'STUDENT' }: SignUpFormProps) => {
                   return (
                     <li
                       key={index}
-                      className={cn(isNested ? 'ml-14' : 'ml-8')}
+                      className={cn('list-disc leading-[1.6]', isNested ? 'ml-10' : 'ml-5')}
                       dangerouslySetInnerHTML={{ __html: trimmedLine.substring(2) }}
                     />
                   );
                 }
                 if (line.startsWith('  > ')) {
                   return (
-                    <blockquote
+                    <li
                       key={index}
-                      className={cn(
-                        'text-muted-foreground border-muted-foreground ml-8 border-l-2 pl-3 italic',
-                      )}
+                      className={cn('ml-10 list-disc leading-[1.6]')}
                       dangerouslySetInnerHTML={{ __html: line.replace('  > ', '') }}
                     />
                   );
@@ -567,24 +579,24 @@ const SignUpForm = ({ objectType = 'STUDENT' }: SignUpFormProps) => {
                 return (
                   <p
                     key={index}
-                    className={cn('my-2')}
+                    className={cn('leading-[1.6]')}
                     dangerouslySetInnerHTML={{ __html: line }}
                   />
                 );
               })}
             </div>
           </div>
-          <div className={cn('flex flex-col gap-2 border-t pt-4')}>
+          <div className={cn('border-border/50 flex flex-col gap-2 border-t p-5')}>
             {!hasScrolledToBottom && (
-              <p className={cn('text-muted-foreground text-center font-mono text-xs')}>
-                {'>'} 내용을 끝까지 읽어주세요
+              <p className={cn("text-muted-foreground text-xs before:mr-1 before:content-['>']")}>
+                내용을 끝까지 읽어주세요
               </p>
             )}
             <button
               onClick={handlePrivacyAgree}
               disabled={!hasScrolledToBottom}
               className={cn(
-                'border-foreground bg-foreground text-background hover:bg-background hover:text-foreground w-full cursor-pointer border-2 py-2.5 font-mono text-xs font-bold uppercase tracking-widest transition-all disabled:cursor-not-allowed disabled:opacity-50',
+                'border-foreground bg-foreground text-background hover:bg-background hover:text-foreground w-full cursor-pointer border-2 py-3 text-xs font-bold tracking-[1.2px] transition-all disabled:cursor-not-allowed disabled:opacity-50',
               )}
             >
               동의합니다

--- a/apps/oauth/src/widgets/signup/ui/SignUpForm/index.tsx
+++ b/apps/oauth/src/widgets/signup/ui/SignUpForm/index.tsx
@@ -494,17 +494,6 @@ const SignUpForm = ({ objectType = 'STUDENT' }: SignUpFormProps) => {
             >
               {isTeacher ? '학생으로 회원가입하나요?' : '선생님으로 회원가입하시나요?'}
             </Link>
-
-            <p className={cn('text-muted-foreground text-center text-xs')}>
-              이미 계정이 있으신가요?{' '}
-              <button
-                type="button"
-                onClick={() => window.close()}
-                className={cn('text-foreground font-semibold underline underline-offset-2')}
-              >
-                창을 닫고 로그인으로 돌아가기
-              </button>
-            </p>
           </div>
         </form>
       </div>

--- a/apps/oauth/src/widgets/signup/ui/SignUpForm/index.tsx
+++ b/apps/oauth/src/widgets/signup/ui/SignUpForm/index.tsx
@@ -504,7 +504,7 @@ const SignUpForm = ({ objectType = 'STUDENT' }: SignUpFormProps) => {
         <DialogContent
           showCloseButton={false}
           className={cn(
-            'border-foreground sm:max-w-160 flex max-h-[80vh] flex-col gap-0 border-2 p-0',
+            'border-foreground sm:max-w-160 [box-shadow:none]! flex max-h-[80vh] flex-col gap-0 border-2 p-0',
           )}
         >
           <DialogHeader

--- a/packages/shared/src/styles/globals.css
+++ b/packages/shared/src/styles/globals.css
@@ -23,6 +23,7 @@
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
+  --color-warning: var(--warning);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -62,6 +63,7 @@
   --accent: oklch(0.92 0 0);
   --accent-foreground: oklch(0.04 0 0);
   --destructive: oklch(0.52 0.245 27.325);
+  --warning: oklch(0.79 0.145 91.1);
   --border: oklch(0.08 0 0);
   --input: oklch(0.9 0 0);
   --ring: oklch(0.04 0 0);
@@ -96,6 +98,7 @@
   --accent: oklch(0.2 0 0);
   --accent-foreground: oklch(0.96 0 0);
   --destructive: oklch(0.65 0.22 27.325);
+  --warning: oklch(0.84 0.145 91.1);
   --border: oklch(1 0 0 / 12%);
   --input: oklch(1 0 0 / 10%);
   --ring: oklch(0.96 0 0);

--- a/packages/shared/src/ui/SignInForm/index.tsx
+++ b/packages/shared/src/ui/SignInForm/index.tsx
@@ -7,18 +7,9 @@ import Link from 'next/link';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { EMAIL_DOMAIN } from '@repo/shared/constants';
 import { ClientAvailableScope, SignInFormSchema, SignInFormType } from '@repo/shared/types';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  FormErrorMessage,
-  Input,
-  Label,
-  Skeleton,
-} from '@repo/shared/ui';
+import { FormErrorMessage, Input, Label, Skeleton } from '@repo/shared/ui';
 import { cn, formatEmailWithDomain } from '@repo/shared/utils';
-import { Clock, Eye, EyeOff, ShieldCheck } from 'lucide-react';
+import { Clock, Eye, EyeOff } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -46,7 +37,6 @@ const SignInForm = ({
   remainingTime,
 }: SignInFormProps) => {
   const [showPassword, setShowPassword] = useState(false);
-  const [isRequestScopeDialogOpen, setIsRequestScopeDialogOpen] = useState(false);
 
   const formatTime = (seconds: number) => {
     const mins = Math.floor(seconds / 60);
@@ -67,246 +57,198 @@ const SignInForm = ({
   });
 
   return (
-    <>
+    <div
+      className={cn(
+        'border-foreground bg-background pixel-shadow-lg relative w-full max-w-sm border-2',
+      )}
+    >
+      {isPending && (
+        <div className="absolute left-[-2px] right-[-2px] top-[-0.5rem] z-10 h-2 overflow-hidden">
+          <div className="animate-progress-bar-loading absolute h-full bg-black" />
+        </div>
+      )}
+
       <div
         className={cn(
-          'border-foreground bg-background pixel-shadow-lg relative w-full max-w-sm border-2',
+          'border-foreground bg-foreground flex items-center gap-3 border-b-2 px-5 py-3',
         )}
       >
+        <div
+          className={cn(
+            'bg-background text-foreground font-pixel flex h-6 w-6 flex-shrink-0 items-center justify-center text-[8px]',
+          )}
+        >
+          D
+        </div>
+        <span className={cn('text-background font-pixel text-[9px]')}>DataGSM</span>
+      </div>
+
+      <div className="relative">
         {isPending && (
-          <div className="absolute left-[-2px] right-[-2px] top-[-0.5rem] z-10 h-2 overflow-hidden">
-            <div className="animate-progress-bar-loading absolute h-full bg-black" />
+          <div className="bg-background/50 absolute inset-0 z-20 flex cursor-not-allowed items-center justify-center" />
+        )}
+
+        {/* Header */}
+        <div className={cn('border-border/50 flex flex-col gap-2 border-b px-6 py-5')}>
+          <h1 className={cn('text-foreground text-xl font-bold')}>로그인</h1>
+          {isLoadingServiceInfo ? (
+            <Skeleton className={cn('h-4 w-48')} />
+          ) : (
+            <div className={cn('flex flex-col gap-1')}>
+              <p className={cn('text-muted-foreground text-xs leading-[18px]')}>
+                <strong className={cn('font-semibold')}>{serviceName || 'DataGSM'}</strong> 로그인을
+                위해 다음 권한을 요청합니다.
+              </p>
+              {serviceScope && serviceScope.length > 0 && (
+                <ul className={cn('flex flex-col gap-1')}>
+                  {serviceScope.map((scope) => (
+                    <li
+                      key={scope.scope}
+                      className={cn(
+                        'text-muted-foreground flex items-center gap-2.5 text-xs leading-4',
+                      )}
+                    >
+                      <span
+                        aria-hidden
+                        className={cn('bg-muted-foreground size-0.5 flex-shrink-0 rounded-full')}
+                      />
+                      {scope.description}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </div>
+
+        {remainingTime !== null && remainingTime !== undefined && remainingTime <= 300 && (
+          <div
+            className={cn(
+              'mx-6 mt-4 flex items-center gap-2 border px-3 py-2 font-mono text-xs font-medium',
+              remainingTime <= 30
+                ? 'border-destructive text-destructive'
+                : 'border-amber-600 text-amber-600',
+            )}
+          >
+            <Clock className={cn('h-3.5 w-3.5 flex-shrink-0')} />
+            <span>세션만료: {formatTime(remainingTime)}</span>
           </div>
         )}
 
-        <div
-          className={cn(
-            'border-foreground bg-foreground flex items-center gap-3 border-b-2 px-5 py-3',
-          )}
-        >
-          <div
-            className={cn(
-              'bg-background text-foreground font-pixel flex h-6 w-6 flex-shrink-0 items-center justify-center text-[8px]',
-            )}
-          >
-            D
-          </div>
-          <span className={cn('text-background font-pixel text-[9px]')}>DataGSM</span>
-        </div>
-
-        <div className="relative">
-          {isPending && (
-            <div className="bg-background/50 absolute inset-0 z-20 flex cursor-not-allowed items-center justify-center" />
-          )}
-
-          {/* Header */}
-          <div className={cn('border-border/50 border-b px-6 py-5')}>
-            <h1 className={cn('text-foreground text-xl font-bold')}>로그인</h1>
-            {isLoadingServiceInfo ? (
-              <Skeleton className={cn('mt-2 h-4 w-48')} />
-            ) : (
-              <p className={cn('text-muted-foreground mt-1 text-sm')}>
-                DataGSM 계정으로{' '}
-                {serviceName ? (
-                  <>
-                    <strong className={cn('text-foreground font-semibold')}>{serviceName}</strong>
-                    에{' '}
-                  </>
-                ) : (
-                  ''
-                )}
-                로그인하세요
-              </p>
-            )}
-          </div>
-
-          {remainingTime !== null && remainingTime !== undefined && remainingTime <= 300 && (
-            <div
-              className={cn(
-                'mx-6 mt-4 flex items-center gap-2 border px-3 py-2 font-mono text-xs font-medium',
-                remainingTime <= 30
-                  ? 'border-destructive text-destructive'
-                  : 'border-amber-600 text-amber-600',
-              )}
-            >
-              <Clock className={cn('h-3.5 w-3.5 flex-shrink-0')} />
-              <span>세션만료: {formatTime(remainingTime)}</span>
-            </div>
-          )}
-
-          <form onSubmit={handleFormSubmit}>
-            <div className={cn('space-y-4 px-6 pt-5')}>
-              <div className={cn('flex items-center gap-2')}>
-                {isLoadingServiceInfo ? (
-                  <Skeleton className={cn('mt-2 h-4 w-48')} />
-                ) : (
-                  <label
-                    className={cn('cursor-pointer text-sm leading-none')}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setIsRequestScopeDialogOpen(true);
-                    }}
-                  >
-                    <span
-                      className={cn(
-                        'text-foreground decoration-border/60 group-hover:decoration-foreground font-semibold underline underline-offset-4 transition-all',
-                      )}
-                    >
-                      {serviceName}
-                    </span>
-                    에서 다음과 같은 권한을 요청합니다
-                  </label>
-                )}
-              </div>
-              {/* Email */}
-              <div className={cn('space-y-1.5')}>
-                <Label
-                  htmlFor="emailLocal"
-                  className={cn(
-                    'text-muted-foreground font-mono text-xs uppercase tracking-widest',
-                  )}
-                >
-                  Email
-                </Label>
-                <div className={cn('flex')}>
-                  <Input
-                    id="emailLocal"
-                    type="text"
-                    placeholder="이메일을 입력하세요"
-                    {...register('email')}
-                    disabled={isPending}
-                    className={cn(
-                      'border-foreground focus-visible:border-foreground flex-1 rounded-none focus-visible:ring-0',
-                    )}
-                  />
-                  <span
-                    className={cn(
-                      'border-foreground bg-muted text-muted-foreground flex items-center whitespace-nowrap border border-l-0 px-3 font-mono text-xs',
-                    )}
-                  >
-                    {EMAIL_DOMAIN}
-                  </span>
-                </div>
-                <FormErrorMessage error={errors.email} />
-              </div>
-
-              {/* Password */}
-              <div className={cn('space-y-1.5')}>
-                <Label
-                  htmlFor="password"
-                  className={cn(
-                    'text-muted-foreground font-mono text-xs uppercase tracking-widest',
-                  )}
-                >
-                  Password
-                </Label>
-                <div className={cn('relative')}>
-                  <Input
-                    id="password"
-                    type={showPassword ? 'text' : 'password'}
-                    placeholder="비밀번호를 입력하세요"
-                    {...register('password')}
-                    disabled={isPending}
-                    className={cn(
-                      'border-foreground focus-visible:border-foreground rounded-none pr-10 focus-visible:ring-0',
-                    )}
-                  />
-                  <button
-                    type="button"
-                    aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
-                    onClick={() => setShowPassword(!showPassword)}
-                    className={cn(
-                      'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
-                      isPending && 'cursor-not-allowed opacity-50',
-                    )}
-                    disabled={isPending}
-                  >
-                    {showPassword ? (
-                      <EyeOff className={cn('h-4 w-4')} />
-                    ) : (
-                      <Eye className={cn('h-4 w-4')} />
-                    )}
-                  </button>
-                </div>
-                <FormErrorMessage error={errors.password} />
-              </div>
-            </div>
-
-            <div className={cn('space-y-3 px-6 pb-6 pt-5')}>
-              <button
-                type="submit"
-                className={cn(
-                  'border-foreground bg-foreground text-background hover:bg-background hover:text-foreground w-full cursor-pointer border-2 px-4 py-3 font-mono text-xs font-bold uppercase tracking-widest transition-all disabled:cursor-not-allowed disabled:opacity-60',
-                )}
-                disabled={isPending}
+        <form onSubmit={handleFormSubmit}>
+          <div className={cn('space-y-4 px-6 pt-5')}>
+            {/* Email */}
+            <div className={cn('space-y-1.5')}>
+              <Label
+                htmlFor="emailLocal"
+                className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
               >
-                {isPending ? 'SIGNING IN...' : 'SIGN IN'}
-              </button>
-
-              {signupHref && (
-                <div className={cn('space-y-1 pt-1 text-center text-xs')}>
-                  <p className={cn('text-muted-foreground')}>
-                    계정이 없으신가요?{' '}
-                    <Link
-                      href={signupHref}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={cn('text-foreground font-semibold underline underline-offset-2')}
-                    >
-                      회원가입
-                    </Link>
-                  </p>
-                  <p>
-                    <Link
-                      href={resetHref}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={cn(
-                        'text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors',
-                      )}
-                    >
-                      비밀번호를 잊으셨나요?
-                    </Link>
-                  </p>
-                </div>
-              )}
-            </div>
-          </form>
-        </div>
-      </div>
-
-      <Dialog open={isRequestScopeDialogOpen} onOpenChange={setIsRequestScopeDialogOpen}>
-        <DialogContent
-          className={cn(
-            'border-foreground pixel-shadow flex max-h-[80vh] max-w-md flex-col border-2',
-          )}
-        >
-          <DialogHeader>
-            <DialogTitle className={cn('text-base font-bold')}>요청된 권한</DialogTitle>
-          </DialogHeader>
-          {serviceScope && serviceScope.length > 0 && (
-            <div className={cn('mx-4 space-y-2')}>
-              <div className={cn('space-y-1.5')}>
-                {serviceScope.map((x, index) => (
-                  <div
-                    key={x.scope + index}
-                    className={cn('bg-muted/30 flex items-center gap-2 border border-dashed p-2')}
-                  >
-                    <ShieldCheck className={cn('text-foreground h-5 w-5 flex-shrink-0')} />
-                    <div className={cn('flex items-baseline gap-2')}>
-                      <p className={cn('text-foreground text-lg font-semibold')}>
-                        {x.applicationName}
-                      </p>
-                      <p className={cn('text-muted-foreground text-sm')}>{x.description}</p>
-                    </div>
-                  </div>
-                ))}
+                Email
+              </Label>
+              <div className={cn('flex')}>
+                <Input
+                  id="emailLocal"
+                  type="text"
+                  placeholder="이메일을 입력하세요"
+                  {...register('email')}
+                  disabled={isPending}
+                  className={cn(
+                    'border-foreground focus-visible:border-foreground flex-1 rounded-none focus-visible:ring-0',
+                  )}
+                />
+                <span
+                  className={cn(
+                    'border-foreground bg-muted text-muted-foreground flex items-center whitespace-nowrap border border-l-0 px-3 font-mono text-xs',
+                  )}
+                >
+                  {EMAIL_DOMAIN}
+                </span>
               </div>
+              <FormErrorMessage error={errors.email} />
             </div>
-          )}
-        </DialogContent>
-      </Dialog>
-    </>
+
+            {/* Password */}
+            <div className={cn('space-y-1.5')}>
+              <Label
+                htmlFor="password"
+                className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
+              >
+                Password
+              </Label>
+              <div className={cn('relative')}>
+                <Input
+                  id="password"
+                  type={showPassword ? 'text' : 'password'}
+                  placeholder="비밀번호를 입력하세요"
+                  {...register('password')}
+                  disabled={isPending}
+                  className={cn(
+                    'border-foreground focus-visible:border-foreground rounded-none pr-10 focus-visible:ring-0',
+                  )}
+                />
+                <button
+                  type="button"
+                  aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+                  onClick={() => setShowPassword(!showPassword)}
+                  className={cn(
+                    'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
+                    isPending && 'cursor-not-allowed opacity-50',
+                  )}
+                  disabled={isPending}
+                >
+                  {showPassword ? (
+                    <EyeOff className={cn('h-4 w-4')} />
+                  ) : (
+                    <Eye className={cn('h-4 w-4')} />
+                  )}
+                </button>
+              </div>
+              <FormErrorMessage error={errors.password} />
+            </div>
+          </div>
+
+          <div className={cn('space-y-3 px-6 pb-6 pt-5')}>
+            <button
+              type="submit"
+              className={cn(
+                'border-foreground bg-foreground text-background hover:bg-background hover:text-foreground w-full cursor-pointer border-2 px-4 py-3 font-mono text-xs font-bold uppercase tracking-widest transition-all disabled:cursor-not-allowed disabled:opacity-60',
+              )}
+              disabled={isPending}
+            >
+              {isPending ? 'SIGNING IN...' : 'SIGN IN'}
+            </button>
+
+            {signupHref && (
+              <div className={cn('space-y-1 pt-1 text-center text-xs')}>
+                <p className={cn('text-muted-foreground')}>
+                  계정이 없으신가요?{' '}
+                  <Link
+                    href={signupHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={cn('text-foreground font-semibold underline underline-offset-2')}
+                  >
+                    회원가입
+                  </Link>
+                </p>
+                <p>
+                  <Link
+                    href={resetHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={cn(
+                      'text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors',
+                    )}
+                  >
+                    비밀번호를 잊으셨나요?
+                  </Link>
+                </p>
+              </div>
+            )}
+          </div>
+        </form>
+      </div>
+    </div>
   );
 };
 

--- a/packages/shared/src/ui/SignInForm/index.tsx
+++ b/packages/shared/src/ui/SignInForm/index.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { EMAIL_DOMAIN } from '@repo/shared/constants';
 import { ClientAvailableScope, SignInFormSchema, SignInFormType } from '@repo/shared/types';
-import { FormErrorMessage, Input, Label, Skeleton } from '@repo/shared/ui';
+import { FormErrorMessage, Input, Skeleton } from '@repo/shared/ui';
 import { cn, formatEmailWithDomain } from '@repo/shared/utils';
 import { Eye, EyeOff } from 'lucide-react';
 import { useForm } from 'react-hook-form';
@@ -59,7 +59,7 @@ const SignInForm = ({
   return (
     <div
       className={cn(
-        'border-foreground bg-background pixel-shadow-lg relative w-full max-w-sm border-2',
+        'border-foreground bg-background pixel-shadow-lg max-w-100 relative w-full border-2',
       )}
     >
       {isPending && (
@@ -70,17 +70,18 @@ const SignInForm = ({
 
       <div
         className={cn(
-          'border-foreground bg-foreground flex items-center gap-3 border-b-2 px-5 py-3',
+          'border-foreground bg-foreground flex items-center gap-3 border-b-2 px-4 py-3',
         )}
       >
         <div
           className={cn(
-            'bg-background text-foreground font-pixel flex h-6 w-6 flex-shrink-0 items-center justify-center text-[8px]',
+            'bg-background text-foreground font-pixel flex size-6 flex-shrink-0 items-center justify-center text-[8px]',
           )}
         >
           D
         </div>
         <span className={cn('text-background font-pixel text-[9px]')}>DataGSM</span>
+        <span className={cn('text-background font-pixel text-[9px]')}>Sign In</span>
       </div>
 
       <div className="relative">
@@ -89,8 +90,8 @@ const SignInForm = ({
         )}
 
         {/* Header */}
-        <div className={cn('border-border/50 flex flex-col gap-2 border-b px-6 py-5')}>
-          <h1 className={cn('text-foreground text-xl font-bold')}>로그인</h1>
+        <div className={cn('border-border/50 flex flex-col gap-2 border-b p-5')}>
+          <h1 className={cn('text-foreground text-xl font-semibold leading-[1.45]')}>로그인</h1>
           {isLoadingServiceInfo ? (
             <Skeleton className={cn('h-4 w-48')} />
           ) : (
@@ -121,95 +122,87 @@ const SignInForm = ({
           )}
         </div>
 
-        {remainingTime !== null && remainingTime !== undefined && (
-          <div
-            className={cn(
-              'border-warning text-warning mx-6 mt-4 flex h-6 items-center border px-2 text-xs font-medium',
-            )}
-            role="status"
-            aria-live="polite"
-          >
-            세션 만료까지: {formatTime(remainingTime)}
-          </div>
-        )}
-
         <form onSubmit={handleFormSubmit}>
-          <div className={cn('space-y-4 px-6 pt-5')}>
-            {/* Email */}
-            <div className={cn('space-y-1.5')}>
-              <Label
-                htmlFor="emailLocal"
-                className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
+          <div className={cn('flex flex-col gap-4 px-5 pt-5')}>
+            {remainingTime !== null && remainingTime !== undefined && (
+              <div
+                className={cn(
+                  'border-warning text-warning flex h-6 items-center border px-2 text-xs font-medium',
+                )}
+                role="status"
+                aria-live="polite"
               >
-                Email
-              </Label>
-              <div className={cn('flex')}>
-                <Input
-                  id="emailLocal"
-                  type="text"
-                  placeholder="이메일을 입력하세요"
-                  {...register('email')}
-                  disabled={isPending}
-                  className={cn(
-                    'border-foreground focus-visible:border-foreground flex-1 rounded-none focus-visible:ring-0',
-                  )}
-                />
-                <span
-                  className={cn(
-                    'border-foreground bg-muted text-muted-foreground flex items-center whitespace-nowrap border border-l-0 px-3 font-mono text-xs',
-                  )}
-                >
-                  {EMAIL_DOMAIN}
-                </span>
+                세션 만료까지: {formatTime(remainingTime)}
               </div>
-              <FormErrorMessage error={errors.email} />
-            </div>
+            )}
 
-            {/* Password */}
-            <div className={cn('space-y-1.5')}>
-              <Label
-                htmlFor="password"
-                className={cn('text-muted-foreground font-mono text-xs uppercase tracking-widest')}
-              >
-                Password
-              </Label>
-              <div className={cn('relative')}>
-                <Input
-                  id="password"
-                  type={showPassword ? 'text' : 'password'}
-                  placeholder="비밀번호를 입력하세요"
-                  {...register('password')}
-                  disabled={isPending}
-                  className={cn(
-                    'border-foreground focus-visible:border-foreground rounded-none pr-10 focus-visible:ring-0',
-                  )}
-                />
-                <button
-                  type="button"
-                  aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
-                  onClick={() => setShowPassword(!showPassword)}
-                  className={cn(
-                    'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
-                    isPending && 'cursor-not-allowed opacity-50',
-                  )}
-                  disabled={isPending}
-                >
-                  {showPassword ? (
-                    <EyeOff className={cn('h-4 w-4')} />
-                  ) : (
-                    <Eye className={cn('h-4 w-4')} />
-                  )}
-                </button>
+            <div className={cn('flex flex-col gap-2')}>
+              {/* Email */}
+              <div className={cn('space-y-1.5')}>
+                <div className={cn('flex')}>
+                  <Input
+                    id="emailLocal"
+                    type="text"
+                    aria-label="이메일"
+                    placeholder="이메일을 입력하세요"
+                    {...register('email')}
+                    disabled={isPending}
+                    className={cn(
+                      'border-foreground focus-visible:border-foreground flex-1 rounded-none focus-visible:ring-0',
+                    )}
+                  />
+                  <span
+                    className={cn(
+                      'border-foreground bg-muted text-muted-foreground flex items-center whitespace-nowrap border border-l-0 px-3 font-mono text-sm',
+                    )}
+                  >
+                    {EMAIL_DOMAIN}
+                  </span>
+                </div>
+                <FormErrorMessage error={errors.email} />
               </div>
-              <FormErrorMessage error={errors.password} />
+
+              {/* Password */}
+              <div className={cn('space-y-1.5')}>
+                <div className={cn('relative')}>
+                  <Input
+                    id="password"
+                    type={showPassword ? 'text' : 'password'}
+                    aria-label="비밀번호"
+                    placeholder="비밀번호를 입력하세요"
+                    {...register('password')}
+                    disabled={isPending}
+                    className={cn(
+                      'border-foreground focus-visible:border-foreground rounded-none pr-10 focus-visible:ring-0',
+                    )}
+                  />
+                  <button
+                    type="button"
+                    aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+                    onClick={() => setShowPassword(!showPassword)}
+                    className={cn(
+                      'text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2 transition-colors',
+                      isPending && 'cursor-not-allowed opacity-50',
+                    )}
+                    disabled={isPending}
+                  >
+                    {showPassword ? (
+                      <EyeOff className={cn('size-4')} />
+                    ) : (
+                      <Eye className={cn('size-4')} />
+                    )}
+                  </button>
+                </div>
+                <FormErrorMessage error={errors.password} />
+              </div>
             </div>
           </div>
 
-          <div className={cn('space-y-3 px-6 pb-6 pt-5')}>
+          <div className={cn('flex flex-col items-center gap-4 p-5')}>
             <button
               type="submit"
               className={cn(
-                'border-foreground bg-foreground text-background hover:bg-background hover:text-foreground w-full cursor-pointer border-2 px-4 py-3 font-mono text-xs font-bold uppercase tracking-widest transition-all disabled:cursor-not-allowed disabled:opacity-60',
+                'border-foreground bg-foreground text-background hover:bg-background hover:text-foreground w-full cursor-pointer border-2 px-4 py-3 font-mono text-xs font-bold uppercase tracking-[1.2px] transition-all disabled:cursor-not-allowed disabled:opacity-60',
               )}
               disabled={isPending}
             >
@@ -217,30 +210,23 @@ const SignInForm = ({
             </button>
 
             {signupHref && (
-              <div className={cn('space-y-1 pt-1 text-center text-xs')}>
-                <p className={cn('text-muted-foreground')}>
-                  계정이 없으신가요?{' '}
-                  <Link
-                    href={signupHref}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={cn('text-foreground font-semibold underline underline-offset-2')}
-                  >
-                    회원가입
-                  </Link>
-                </p>
-                <p>
-                  <Link
-                    href={resetHref}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={cn(
-                      'text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors',
-                    )}
-                  >
-                    비밀번호를 잊으셨나요?
-                  </Link>
-                </p>
+              <div className={cn('flex items-center justify-center gap-2 text-xs')}>
+                <Link
+                  href={signupHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={cn('text-foreground underline underline-offset-2')}
+                >
+                  회원가입
+                </Link>
+                <Link
+                  href={resetHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={cn('text-foreground underline underline-offset-2')}
+                >
+                  비밀번호 찾기
+                </Link>
               </div>
             )}
           </div>

--- a/packages/shared/src/ui/SignInForm/index.tsx
+++ b/packages/shared/src/ui/SignInForm/index.tsx
@@ -9,7 +9,7 @@ import { EMAIL_DOMAIN } from '@repo/shared/constants';
 import { ClientAvailableScope, SignInFormSchema, SignInFormType } from '@repo/shared/types';
 import { FormErrorMessage, Input, Label, Skeleton } from '@repo/shared/ui';
 import { cn, formatEmailWithDomain } from '@repo/shared/utils';
-import { Clock, Eye, EyeOff } from 'lucide-react';
+import { Eye, EyeOff } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -41,7 +41,7 @@ const SignInForm = ({
   const formatTime = (seconds: number) => {
     const mins = Math.floor(seconds / 60);
     const secs = seconds % 60;
-    return `${mins}:${secs.toString().padStart(2, '0')}`;
+    return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
   };
 
   const {
@@ -121,17 +121,15 @@ const SignInForm = ({
           )}
         </div>
 
-        {remainingTime !== null && remainingTime !== undefined && remainingTime <= 300 && (
+        {remainingTime !== null && remainingTime !== undefined && (
           <div
             className={cn(
-              'mx-6 mt-4 flex items-center gap-2 border px-3 py-2 font-mono text-xs font-medium',
-              remainingTime <= 30
-                ? 'border-destructive text-destructive'
-                : 'border-amber-600 text-amber-600',
+              'border-warning text-warning mx-6 mt-4 flex h-6 items-center border px-2 text-xs font-medium',
             )}
+            role="status"
+            aria-live="polite"
           >
-            <Clock className={cn('h-3.5 w-3.5 flex-shrink-0')} />
-            <span>세션만료: {formatTime(remainingTime)}</span>
+            세션 만료까지: {formatTime(remainingTime)}
           </div>
         )}
 

--- a/packages/shared/src/ui/SignInForm/index.tsx
+++ b/packages/shared/src/ui/SignInForm/index.tsx
@@ -57,11 +57,7 @@ const SignInForm = ({
   });
 
   return (
-    <div
-      className={cn(
-        'border-foreground bg-background pixel-shadow-lg max-w-100 relative w-full border-2',
-      )}
-    >
+    <div className={cn('border-foreground bg-background max-w-100 relative w-full border-2')}>
       {isPending && (
         <div className="absolute left-[-2px] right-[-2px] top-[-0.5rem] z-10 h-2 overflow-hidden">
           <div className="animate-progress-bar-loading absolute h-full bg-black" />

--- a/packages/shared/src/ui/SignInForm/index.tsx
+++ b/packages/shared/src/ui/SignInForm/index.tsx
@@ -140,11 +140,12 @@ const SignInForm = ({
                     id="emailLocal"
                     type="text"
                     aria-label="이메일"
+                    aria-invalid={!!errors.email}
                     placeholder="이메일을 입력하세요"
                     {...register('email')}
                     disabled={isPending}
                     className={cn(
-                      'border-foreground focus-visible:border-foreground flex-1 rounded-none focus-visible:ring-0',
+                      'border-foreground focus-visible:border-foreground aria-invalid:border-destructive aria-invalid:text-destructive flex-1 rounded-none focus-visible:ring-0',
                     )}
                   />
                   <span
@@ -155,7 +156,12 @@ const SignInForm = ({
                     {EMAIL_DOMAIN}
                   </span>
                 </div>
-                <FormErrorMessage error={errors.email} />
+                <FormErrorMessage
+                  error={errors.email}
+                  className={cn(
+                    "text-destructive text-xs leading-4 before:mr-1 before:content-['>']",
+                  )}
+                />
               </div>
 
               {/* Password */}
@@ -165,11 +171,12 @@ const SignInForm = ({
                     id="password"
                     type={showPassword ? 'text' : 'password'}
                     aria-label="비밀번호"
+                    aria-invalid={!!errors.password}
                     placeholder="비밀번호를 입력하세요"
                     {...register('password')}
                     disabled={isPending}
                     className={cn(
-                      'border-foreground focus-visible:border-foreground rounded-none pr-10 focus-visible:ring-0',
+                      'border-foreground focus-visible:border-foreground aria-invalid:border-destructive aria-invalid:text-destructive rounded-none pr-10 focus-visible:ring-0',
                     )}
                   />
                   <button
@@ -189,7 +196,12 @@ const SignInForm = ({
                     )}
                   </button>
                 </div>
-                <FormErrorMessage error={errors.password} />
+                <FormErrorMessage
+                  error={errors.password}
+                  className={cn(
+                    "text-destructive text-xs leading-4 before:mr-1 before:content-['>']",
+                  )}
+                />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## 개요 💡

DG 디자인 리팩토링에 따라 `apps/oauth`의 화면들을 신규 Figma 디자인에 맞게 수정합니다.

가장 큰 변화는 두 가지입니다.

- **로그인 동의 화면**: 요청 권한 목록이 숨은 다이얼로그에서 나와 카드 안에 항상 표시되고, 세션 만료가 시점별 토스트 대신 상시 카운트다운 배너로 바뀝니다. DataGSM을 처음 보는 학생이 무엇을 넘기는지 로그인 전에 확인할 수 있게 됩니다.
- **회원가입 플로우**: 한 페이지에서 학생/선생님을 토글하던 방식을 없애고, 학생 회원가입을 기본으로 두고 선생님 회원가입은 별도 페이지(`/signup/teacher`)로 분리합니다.

그 외 화면들도 동일한 카드 규격(폭 400px, 여백 20px, 타이틀 바, 그림자 없음)으로 통일했습니다.

Figma: [로그인](https://www.figma.com/design/ORoVsjQjsylD6sKXWF4uyj/DataGSM?node-id=248-4300) / [세션 만료](https://www.figma.com/design/ORoVsjQjsylD6sKXWF4uyj/DataGSM?node-id=258-4512) / [에러 상태](https://www.figma.com/design/ORoVsjQjsylD6sKXWF4uyj/DataGSM?node-id=258-4369) / [회원가입](https://www.figma.com/design/ORoVsjQjsylD6sKXWF4uyj/DataGSM?node-id=258-4655) / [선생님 회원가입](https://www.figma.com/design/ORoVsjQjsylD6sKXWF4uyj/DataGSM?node-id=258-4819) / [개인정보 처리방침](https://www.figma.com/design/ORoVsjQjsylD6sKXWF4uyj/DataGSM?node-id=259-4783) / [비밀번호 초기화](https://www.figma.com/design/ORoVsjQjsylD6sKXWF4uyj/DataGSM?node-id=259-4843)

## 작업내용 ⌨️

### 로그인 동의 (`/oauth/authorize`)

- 요청 권한 목록을 다이얼로그에서 꺼내 카드 안에 인라인으로 상시 표시 (스코프 식별자가 아닌 `description` 라벨 사용)
- 세션 만료를 시점별(5분/1분/30초) 토스트에서 **상시 카운트다운 배너**로 변경, 배너 색상(`#ddb636`)을 `--warning` 토큰으로 추가
- 세션 만료 모달을 타이틀 바 구조(`DataGSM Session Expiration`)로 재구성하고 경고 아이콘 제거
- 검증 실패 시 `aria-invalid` 기반으로 입력 테두리·문구를 `destructive` 색으로 표시하고, 에러 메시지를 필드 바로 아래 `> ` 접두 형식으로 표기

### 회원가입 (`/signup`, `/signup/teacher`)

- 가입 종류 토글 버튼 제거 → 학생 페이지가 기본, 하단 링크로 선생님 페이지 이동 (양방향)
- 스키마를 `StudentSignUpFormSchema` / `TeacherSignUpFormSchema`로 분리하고 `objectType` 폼 필드 제거
- 이메일 인증 상태(전송·검증·5분 쿨다운·localStorage)를 `useEmailVerification` 훅으로 추출
- 폼은 `objectType`을 prop으로 받아 제목·선생님 정보 섹션·하단 링크만 분기
- 섹션 라벨(이메일 인증 / 비밀번호 / 선생님 정보) 구조로 재구성
- 하단 "이미 계정이 있으신가요? 창을 닫고 로그인으로 돌아가기" 문구 제거

### 개인정보 처리방침 다이얼로그

- 타이틀 바 구조(`privacy policy` + X 버튼) 적용, 폭 640px로 확대, 그림자 제거
- 본문 타이포그래피 조정 (제목 16px / 섹션 14px / 본문 13px, 행간 1.6)
- **문구는 기존 내용 그대로 유지**

### 비밀번호 초기화 (`/signin/reset-password`)

- 카드 규격 통일 및 그림자 제거, 섹션 라벨 구조로 재구성
- 제목을 "비밀번호 초기화"로, 하단을 "비밀번호가 기억나셨나요?" 링크로 변경

### API

**API 엔드포인트·요청 바디·에러 매핑·성공 후 이동 경로는 모두 기존과 동일합니다.** 이번 PR은 화면 구성과 라우팅만 변경합니다.

## 스크린샷/동영상 📸

<img width="706" height="746" alt="image" src="https://github.com/user-attachments/assets/4e16e0cf-ec14-49c2-b0e4-ae26db8742b0" />
<img width="694" height="954" alt="image" src="https://github.com/user-attachments/assets/ea05337f-a64a-4624-bfd9-c7cfd21fab7a" />
<img width="676" height="1326" alt="image" src="https://github.com/user-attachments/assets/511bbe03-49b1-40ab-9b36-4d8a772e3990" />
<img width="708" height="884" alt="image" src="https://github.com/user-attachments/assets/ec9da417-b4e2-4d61-b6b4-194bf379da02" />


## 리뷰 요청사항 👀

디자인 시안을 그대로 따르지 않고 판단한 부분이 있어 확인 부탁드립니다.

- **세션 만료 모달 색상**: 시안은 `#f35248`이지만 기존 `destructive` 토큰을 그대로 사용했습니다. 라이트 모드에서는 시안보다 진한 `#d20000`으로 보입니다. (토큰을 시안에 맞추면 admin/client의 삭제 버튼 등 전 앱에 영향이 갑니다)
- **세션 배너**: 기존에는 30초 이하에서 빨간색으로 바뀌었으나, 시안에 해당 상태가 없어 항상 황색으로 두었습니다.
- **선생님 소속 부서**: 시안은 일반 입력처럼 보이지만 API가 enum(`TeacherDepartment`)을 받으므로 Select를 유지했습니다.
- **선생님 제출 버튼**: 시안대로 `SIGN UP`으로 두었습니다. 기존에는 "회원가입 신청"이었는데, 승인 대기 성격을 문구로 알리는 게 낫다면 되돌리겠습니다.
- **비밀번호 초기화 화면**: 시안의 타이틀 바와 제출 버튼이 `Sign Up` / `SIGN UP`으로 되어 있어 다른 화면에서 복사된 것으로 보고 `Reset Password` / `RESET PASSWORD`로 넣었습니다.
- **개인정보 처리방침 동의 버튼**: 시안에는 활성 상태만 있지만, 끝까지 스크롤해야 활성화되는 기존 제약은 동의 절차에 관한 동작이라 유지했습니다.
- **개인정보 처리방침 그림자**: 공용 `Dialog`의 기본 스타일에 `pixel-shadow`가 있어 이 다이얼로그에서만 덮어썼습니다. 전역적으로 그림자를 걷어내는 방향이라면 공용 컴포넌트를 수정하는 편이 나을 것 같습니다.
